### PR TITLE
feat(habit): add habit and mood tracking to Home Assistant

### DIFF
--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -20,6 +20,57 @@ version_file_committer:
   github_token: !secret appdaemon_github_token
   github_email: !secret google_maps_location_tracker_email
 
+# Habit and Mood Tracker
+
+habit_tracker:
+  module: habit.habit_tracker
+  class: HabitTracker
+  users:
+    - will
+    - vic
+  store_directory: /homeassistant/.appdaemon/habits
+  reminders_enabled: false
+  ai_task_entity: ai_task.habit_reminder_ai
+
+  mqtt_host: !secret appdaemon_mqtt_host
+  mqtt_port: 1883
+  mqtt_username: !secret appdaemon_mqtt_username
+  mqtt_password: !secret appdaemon_mqtt_password
+  mqtt_discovery_prefix: homeassistant
+  mqtt_base_topic: appdaemon/habits
+
+  context_labels:
+    calendar:
+      will: habit_context_calendar_will
+      vic: habit_context_calendar_vic
+    home: habit_context_home
+    work: habit_context_work
+    family: habit_context_family
+
+  user_config:
+    will:
+      notify_script: script.notify_will
+      dashboard_url: /home-will/health-fitness
+      person_entity: person.will
+      at_work_entity: binary_sensor.will_at_work
+      workday_entity: binary_sensor.workday
+      activity_entity: sensor.will_s_pixel_6_pro_detected_activity
+      steps_entity: sensor.will_s_pixel_6_pro_daily_steps
+      exercise_entity: sensor.joroto_exercise_bike_active_time
+      weather_entity: weather.met_office_fulham
+      sun_entity: sun.sun
+    vic:
+      notify_script: script.notify_vic
+      dashboard_url: /dashboard-mobile/vic-habits
+      person_entity: person.vic
+      at_work_entity: binary_sensor.vic_at_work
+      workday_entity: binary_sensor.workday
+      activity_entity: sensor.vics_iphone_activity
+      steps_entity: sensor.vics_iphone_steps
+      exercise_entity: sensor.joroto_exercise_bike_active_time
+      weather_entity: weather.met_office_fulham
+      sun_entity: sun.sun
+
 # Pro Breeze AC
 
 pro_breeze_ac:
@@ -81,8 +132,8 @@ slc_balance:
 # Log Processor
 
 # log_processor:
-  # module: log_processor
-  # class: LogProcessor
+#   module: log_processor
+#   class: LogProcessor
 
 # Monzo
 

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -72,7 +72,6 @@ habit_tracker:
       workday_entity: binary_sensor.workday
       activity_entity: sensor.will_s_pixel_6_pro_detected_activity
       steps_entity: sensor.will_s_pixel_6_pro_daily_steps
-      exercise_entity: sensor.joroto_exercise_bike_active_time
       weather_entity: weather.met_office_fulham
       sun_entity: sun.sun
     vic:
@@ -83,7 +82,6 @@ habit_tracker:
       workday_entity: binary_sensor.workday
       activity_entity: sensor.vics_iphone_activity
       steps_entity: sensor.vics_iphone_steps
-      exercise_entity: sensor.joroto_exercise_bike_active_time
       weather_entity: weather.met_office_fulham
       sun_entity: sun.sun
 

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -71,9 +71,7 @@ habit_tracker:
       at_work_entity: binary_sensor.will_at_work
       workday_entity: binary_sensor.workday
       activity_entity: sensor.will_s_pixel_6_pro_detected_activity
-      steps_entity: sensor.will_s_pixel_6_pro_daily_steps
       weather_entity: weather.met_office_fulham
-      sun_entity: sun.sun
     vic:
       notify_script: script.notify_vic
       dashboard_url: /dashboard-mobile/vic-habits
@@ -81,9 +79,7 @@ habit_tracker:
       at_work_entity: binary_sensor.vic_at_work
       workday_entity: binary_sensor.workday
       activity_entity: sensor.vics_iphone_activity
-      steps_entity: sensor.vics_iphone_steps
       weather_entity: weather.met_office_fulham
-      sun_entity: sun.sun
 
 # Pro Breeze AC
 

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -46,6 +46,10 @@ habit_tracker:
     - vic
   store_directory: /homeassistant/.appdaemon/habits
   reminders_enabled: true
+  # Cutover flag: leave false until the new completion entities are configured
+  # and verified, then enable to let templates complete habits.
+  template_evaluation_enabled: false
+  template_eval_debounce_seconds: 2
   ai_task_entity: ai_task.habit_reminder_ai
 
   mqtt_host: !secret appdaemon_mqtt_host

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -45,7 +45,7 @@ habit_tracker:
     - will
     - vic
   store_directory: /homeassistant/.appdaemon/habits
-  reminders_enabled: false
+  reminders_enabled: true
   ai_task_entity: ai_task.habit_reminder_ai
 
   mqtt_host: !secret appdaemon_mqtt_host

--- a/apps/habit/EVENT_DRIVEN_PLAN.md
+++ b/apps/habit/EVENT_DRIVEN_PLAN.md
@@ -1,0 +1,608 @@
+# Event-Driven Habit Completion — Plan and Handoff
+
+This document has two parts:
+
+- **Part A** — the implementation plan as originally written, reproduced verbatim.
+- **Part B** — a handoff for whoever picks this up next, covering what is actually
+  built, where the code deviates from Part A, and what to do first.
+
+Part A is a historical record and is **not** updated as work lands. Where Part A and
+Part B disagree, **Part B is correct**.
+
+---
+---
+
+# Part A — Implementation plan (verbatim)
+
+# Event-Driven Habit Completion — Implementation Plan
+
+Extends the AppDaemon habit tracker (`feature/habits`) so a habit can complete itself
+when a user-defined Jinja template evaluates truthy — either instantly, after an
+unbroken block of N minutes, or after N minutes accumulated across the day.
+
+**Agreed scope**
+
+| Decision | Choice |
+|---|---|
+| Modes | `manual`, `instant`, `continuous`, `summed` |
+| Habit types | Binary only (countable stays manual/instant) |
+| Manual switch | Still works; template never un-completes; manual un-tick stops auto-completion for that day |
+| Time in templates | Via `sensor.time` / `sensor.date`, never `now()` |
+
+Findings below were verified against the live instance on 2026-07-28.
+
+---
+
+## Landmine: bumping `SCHEMA_VERSION` destroys the store
+
+`StoreData.from_dict` raises `ValueError` when `schema_version != SCHEMA_VERSION`
+(`models.py:269-271`). `HabitStore._load` catches `ValueError` and **quarantines** the
+file — then does the same to the backup, and falls through to `StoreData.empty()`
+(`store.py:47-53`). So changing `SCHEMA_VERSION` from `1` to `2` silently wipes every
+habit config and all completion history on first boot.
+
+Fix before touching the schema — accept old versions and upgrade in place:
+
+```python
+SCHEMA_VERSION: Final[int] = 2
+
+@classmethod
+def from_dict(cls, value: dict[str, Any]) -> Self:
+    version = _integer(value, "schema_version")
+    if version > SCHEMA_VERSION:
+        raise ValueError(f"unsupported schema version: {version}")
+    if version < SCHEMA_VERSION:
+        value = _migrate(value, from_version=version)
+    ...
+```
+
+`_migrate` for 1→2 is a no-op beyond stamping the new version, because every field added
+below has a default. But the mechanism must exist *before* the first bump.
+
+This is Phase 0 and is worth doing regardless of whether the rest gets built.
+
+---
+
+## Design
+
+### Completion modes
+
+| Mode | Behaviour |
+|---|---|
+| `manual` | Current behaviour. Template ignored. |
+| `instant` | Rising edge false→true completes the habit. |
+| `continuous` | Truthy for `duration_minutes` unbroken completes the habit. |
+| `summed` | Truthy for `duration_minutes` total across the local day completes the habit. |
+
+### How the timers work
+
+`self.run_in(callback, seconds)` schedules a one-shot callback and returns a handle;
+`self.cancel_timer(handle)` drops it. `ReminderManager` already does exactly this — one
+handle per slot, cancel-and-replace on change. Duration tracking is the same shape:
+
+- Template goes **true** → arm a timer for the remaining time.
+- Template goes **false** before it fires → cancel the timer.
+- Timer **fires** → the condition held for the full window → complete the habit.
+
+No polling loop, no tick counting. The timer firing *is* the proof the window elapsed.
+`summed` differs only in arming for `target − already_banked` rather than the full
+duration.
+
+### `sensor.time` is the reconciliation poll
+
+Verified on the live instance: `sensor.time` updates exactly on the minute
+(`last_changed` = `01:07:00.014`). Any template referencing it therefore emits a
+state-change event every 60 seconds — which is precisely the reconciliation poll this
+design needs, delivered by the event bus for free.
+
+Because time is expressed via `sensor.time`/`sensor.date` rather than `now()`, every
+template dependency is a real entity. That means:
+
+- regex extraction + `listen_state` genuinely covers all dependencies
+- there is no `listeners.all`-style opacity to work around
+- **no hand-rolled `run_every` poll is needed anywhere**
+
+One refinement: for `continuous` and `summed` modes, **always subscribe to `sensor.time`
+whether or not the template references it.** Guaranteed minute-tick reconciliation
+bounding any drift from a missed transition, at the cost of one extra listener.
+
+> **Rejected: HA websocket `render_template` subscription.** It returns an authoritative
+> `listeners: {all, entities, domains, time}` and pushes re-renders, which would remove
+> regex extraction entirely. But its value is concentrated in correct `now()` handling
+> and opacity detection — neither of which applies here. Not worth a second connection,
+> a long-lived token, and reconnect logic. Revisit only if `now()` becomes unavoidable.
+
+### Template return types
+
+Verified: a **single pure expression returns a native JSON boolean**.
+
+```jinja
+{{ states('sensor.time') >= '18:00' and is_state('binary_sensor.will_at_work','off') }}
+→ false          (native bool)
+```
+
+Anything with literal text or multiple expressions returns a **string**:
+
+```jinja
+int:{{ ... }}|cmp:{{ ... }}
+→ "int:100|cmp:False"
+```
+
+So `coerce_truthy` is still required — `bool("False")` is `True` — but the common
+one-expression case needs no coercion at all.
+
+Failure modes degrade safely: `states('sensor.missing') | float(0) > 1` returns `False`
+rather than raising, and `| int(0)` correctly handles float-strings like `"100.0"`
+(as emitted by `sensor.will_s_pixel_6_pro_daily_steps`). A renamed entity fails falsy
+rather than erroring, provided filter defaults are used.
+
+### The 255-character limit
+
+HA states cap at 255 characters and the template lives in a `text` entity, so that is the
+ceiling. In practice it is roomy — a realistic three-clause condition against one of the
+longest entity IDs in the config is ~155 characters:
+
+```jinja
+{{ states('sensor.time') >= '18:00' and is_state('binary_sensor.will_at_work','off') and states('sensor.will_s_pixel_6_pro_daily_steps')|float(0) > 8000 }}
+```
+
+Validate length on the MQTT command path, reject over-long templates with a clear log
+line, and surface `template_error` in the slot attributes. See the appendix for an
+uncapped escape hatch if it ever becomes a real constraint.
+
+### Restart recovery
+
+Rule: **banked time survives a restart; in-flight time across a restart is discarded.**
+
+- `accumulated_seconds` was earned and observed — keep it.
+- The open `truthy_since` block cannot be verified as unbroken while the app was down —
+  discard the gap, re-stamp `truthy_since = now` if the template is truthy at startup.
+
+Conservative, never over-credits, needs no heartbeat.
+
+---
+
+## Data model
+
+### `models.py`
+
+```python
+class CompletionMode(StrEnum):
+    MANUAL = "manual"
+    INSTANT = "instant"
+    CONTINUOUS = "continuous"
+    SUMMED = "summed"
+
+MAX_TEMPLATE_LENGTH: Final[int] = 255
+TIME_TICK_ENTITY: Final[str] = "sensor.time"
+```
+
+New `HabitConfig` fields (all defaulted, so v1 stores parse unchanged):
+
+```python
+completion_mode: CompletionMode = CompletionMode.MANUAL
+completion_template: str = ""
+completion_duration_minutes: int = 30
+```
+
+`__post_init__` additions:
+
+- `len(completion_template) <= MAX_TEMPLATE_LENGTH`
+- `1 <= completion_duration_minutes <= 1440`
+- if `completion_mode is not MANUAL` then `completion_template.strip()` must be non-empty
+- if `completion_mode` is a duration mode then `habit_type` must be `BINARY`
+
+New dataclass:
+
+```python
+@dataclass(slots=True)
+class TemplateProgress:
+    day: str                         # ISO local date this accumulator belongs to
+    accumulated_seconds: int = 0     # banked truthy time today (summed only)
+    truthy_since: str | None = None  # UTC ISO, set while currently truthy
+    suppressed_day: str | None = None  # set on manual un-tick; blocks re-completion
+```
+
+Current truthiness is derived from `truthy_since is not None` — no separate flag to keep
+in sync.
+
+`UserData` gains `template_progress: dict[int, TemplateProgress]`, serialised like
+`pending_reminders` (string slot keys). Drop it in `normalize_spare_slot` so a reused
+slot never inherits stale progress.
+
+### New module: `apps/habit/templates.py`
+
+Mirrors `reminders.py` — owns extraction, coercion, and timer handles; no AppDaemon
+imports beyond a `Protocol`, so the pure parts stay unit-testable.
+
+```python
+ENTITY_PATTERN = re.compile(r"\b([a-z_]{3,})\.([a-z0-9_]+)\b")
+
+def extract_entities(template: str) -> tuple[str, ...]: ...
+def coerce_truthy(value: object) -> bool: ...
+```
+
+`coerce_truthy` must be explicit:
+
+- `True` for `True`, `"true"`, `"on"`, `"yes"`, `"1"`, numeric > 0
+- `False` for `False`, `"false"`, `"off"`, `"no"`, `"0"`, `""`, `"none"`, `"unknown"`,
+  `"unavailable"`, numeric 0
+- anything else → `False` + one log line
+
+`TemplateWatcher` holds `dict[tuple[str, int], str]` timer handles plus listener handles,
+exposing `arm`, `cancel`, `cancel_all`, `release` — same surface as `ReminderManager`.
+
+---
+
+## Wiring into `habit_tracker.py`
+
+### Evaluation entry point
+
+```python
+def _evaluate_template(self, user: str, slot: int) -> None:
+```
+
+1. Return if `not self.template_evaluation_enabled`.
+2. Return unless configured, mode is not `manual`, and template non-empty.
+3. Return if `progress.suppressed_day == today` (manual un-tick honoured).
+4. If complete today → clear progress, cancel timer, return.
+5. Render via `self.render_template(...)` in `try/except` → failure is falsy, logged
+   rate-limited, `template_error` set in attributes.
+6. `now_truthy = coerce_truthy(result)`; `was_truthy = progress.truthy_since is not None`.
+7. Dispatch on mode.
+
+**`instant`** — `not was_truthy and now_truthy` → `self._set_completion(user, slot, 1)`.
+
+**`continuous`**
+- rising: `truthy_since = now`, arm timer for `duration * 60`
+- falling: clear `truthy_since`, cancel timer
+- timer fires: **re-render to confirm still truthy**, then complete
+
+**`summed`**
+- rising: `truthy_since = now`, arm for `target − accumulated`
+- falling: `accumulated += now − truthy_since`, clear, cancel
+- timer fires: bank elapsed; complete if `accumulated >= target`, else re-arm remainder
+
+### Listener management
+
+`_rebuild_template_listeners(user, slot)` — cancel existing handles, extract entities,
+`listen_state` each onto the debounced evaluator. For duration modes, add
+`TIME_TICK_ENTITY` unconditionally. Call on init, template change, mode change, and slot
+retirement.
+
+Publish the resolved list as a `watched_entities` attribute so a regex miss is visible
+rather than mysterious.
+
+### Debounce
+
+Coalesce per slot with a short `run_in`, cancelling any pending evaluation handle first:
+
+```python
+def _schedule_evaluation(self, user: str, slot: int) -> None:  # ~2s debounce
+```
+
+Protects against several dependencies changing at once and against flapping templates
+churning `store.save()`.
+
+### Touchpoints in existing code
+
+| Location | Change |
+|---|---|
+| `initialize` | Build watcher, rebuild listeners, deferred `run_in` recovery pass alongside `_restore_reminders_callback` |
+| `_update_habit` | New keys `completion_mode`, `completion_template`, `completion_duration`; rebuild listeners and re-evaluate after any change |
+| `_set_completion` | On completion, clear progress + cancel timer. On manual un-tick (`count == 0`), set `suppressed_day = today` and clear progress |
+| `_midnight_rollover` | Reset `template_progress` to fresh `TemplateProgress(day=today)`; clear `suppressed_day`; re-evaluate every event-driven slot |
+| `terminate` | `watcher.cancel_all()` before the existing store save |
+| `normalize_spare_slot` | Drop `template_progress` for retired slots |
+
+---
+
+## MQTT surface (`mqtt.py`)
+
+New `EntitySpec`s per slot, all `entity_category: config`:
+
+| Component | Key | Notes |
+|---|---|---|
+| `select` | `completion_mode` | options `manual/instant/continuous/summed` |
+| `text` | `completion_template` | `max: 255` |
+| `number` | `completion_duration` | 1–1440, `unit_of_measurement: min` |
+
+Observability (cheap, and makes debugging *why* a habit isn't progressing much easier):
+
+| Component | Key | Notes |
+|---|---|---|
+| `binary_sensor` | `condition` | live truthiness; attributes carry `template_error`, `watched_entities`, `accumulated_minutes` |
+| `sensor` | `condition_progress` | minutes banked vs target, `unit_of_measurement: min` |
+
+Add all new keys to `_slot_entity_keys()` so retirement cleans them up, and to
+`publish_config_state`. Note `binary_sensor` needs no `command_topic` — the existing
+`if spec.component != "sensor"` guard must become a set check.
+
+---
+
+## Config (`apps.yaml`)
+
+```yaml
+  template_evaluation_enabled: false   # cutover flag, mirrors reminders_enabled
+  template_eval_debounce_seconds: 2
+```
+
+No poll interval — `sensor.time` provides the tick. Validate with the same bounds
+treatment as `mqtt_port`.
+
+---
+
+## Validation rules
+
+Deliberately narrow. Do **not** block on heuristics.
+
+| Check | Action |
+|---|---|
+| Syntax error on set-time render | Reject, log, set `template_error` |
+| Over 255 characters | Reject with a clear message |
+| **Extracted entity list empty** | Flag loudly — the template is a constant and will never re-evaluate |
+| Result not boolean-ish | Warn, treat via `coerce_truthy` |
+| Duration mode on a countable habit | Reject in `__post_init__` |
+
+---
+
+## Phasing
+
+Each phase is independently shippable and leaves the app working.
+
+| Phase | Work | Risk |
+|---|---|---|
+| **0** | `_migrate` + version-tolerant `from_dict`; verify a v1 store loads and is not quarantined | Low, highest value |
+| **1** | Model fields, `TemplateProgress`, MQTT entities, `_update_habit` keys. No evaluation | Low |
+| **2** | `templates.py`, extraction/coercion, listeners, debounce, **`instant`** mode | Medium |
+| **3** | **`continuous`** — timers, re-render confirmation, restart recovery, `sensor.time` subscription | Medium |
+| **4** | **`summed`** — accumulator, midnight reset | Medium |
+| **5** | `binary_sensor`/progress sensor, README, remove cutover flag | Low |
+
+---
+
+## Verification
+
+No test harness exists (no `tests/`, dev group is `appdaemon` + `basedpyright`), and
+`basedpyright` runs in **strict** mode via pre-commit — new code needs complete
+annotations and no blanket `# type: ignore` (a pre-commit hook enforces that).
+
+The pure functions in `templates.py` (`extract_entities`, `coerce_truthy`) and the
+progress arithmetic are testable without AppDaemon. Worth adding a minimal `tests/`
+directory with `pytest` for those plus the streak functions — most logic per line, least
+framework coupling.
+
+Manual verification per phase:
+
+1. `pre-commit run --all-files` (ruff, basedpyright strict, codespell).
+2. Deploy with `template_evaluation_enabled: false`; confirm entities appear, nothing fires.
+3. Point a template at a hand-togglable helper — verify rising edge, falling edge, timer
+   completion.
+4. Restart mid-progress; confirm banked time survives and in-flight time resets.
+5. Cross midnight with a persistently truthy template; confirm the accumulator resets.
+6. Confirm `store.json.backup` stays valid and nothing lands in `*.invalid-*`.
+
+---
+
+## Appendix: uncapped template input, if 255 ever bites
+
+The 255 limit applies to *states*, not to service-call data or MQTT payloads. A script
+with a multiline field can publish straight to the existing command topic, bypassing the
+text entity entirely:
+
+```yaml
+fields:
+  template:
+    selector:
+      text:
+        multiline: true
+
+sequence:
+  - action: mqtt.publish
+    data:
+      topic: "appdaemon/habits/{{ user }}/{{ slot }}/completion_template/set"
+      payload: "{{ template }}"
+```
+
+AppDaemon already subscribes to `appdaemon/habits/+/+/+/set`, so this needs no new
+handling. Display the stored value back via a sensor *attribute* (uncapped) rather than a
+state. Not worth building until a real template needs it.
+
+An alias layer (`$steps` → `states('sensor.will_s_pixel_6_pro_daily_steps')|int(0)`) would
+also compress most of the length out of typical templates, but is unnecessary at current
+lengths.
+
+---
+
+## Open questions
+
+- **Instant + a persistently truthy template** re-completes at 00:00 daily. Probably
+  desired for "steps > 8000", but should be a deliberate choice.
+- **Flapping hysteresis** — a template hovering at a threshold resets `continuous`
+  forever. A minimum-dwell before counting a falling edge would fix it, at the cost of
+  another config knob.
+- **Countable habits** are excluded from duration modes but could use `instant` to set a
+  value; would need rules for what the template returns.
+
+---
+---
+
+# Part B — Handoff
+
+Written 2026-07-28. Phases 0, 1 and 2 are complete and committed.
+
+## Where things stand
+
+Branch `feature/habits`, working tree clean at time of writing.
+
+| Commit | Contents |
+|---|---|
+| `bef4153` | Phase 0 — schema version migration handling |
+| `7010faa` | Phase 1 — event-driven completion config surface |
+| `1e3762b` | Phase 2 — template-driven completion (`instant`) |
+
+Phases 3, 4 and 5 remain. **Start with Phase 3 (`continuous`).**
+
+## What is actually built
+
+**`models.py`**
+
+- `SCHEMA_VERSION = 2`, `MIN_SCHEMA_VERSION = 1`.
+- `UnsupportedSchemaVersionError(ValueError)` — distinguishes "intact but from another
+  build" from "corrupt".
+- `SCHEMA_MIGRATIONS: dict[int, Callable]` with `_migrate_1_to_2` registered (additive
+  no-op), driven by `migrate_store_payload()`. A missing step is fatal, never skipped.
+- `CompletionMode` with `is_event_driven` and `is_duration_based` properties.
+- `HabitConfig.completion_mode` / `completion_template` / `completion_duration_minutes`,
+  validated in `_validate_completion()`.
+- `TemplateProgress` with `day`, `accumulated_seconds`, `truthy_since`, `suppressed_day`
+  and an `is_truthy` property.
+- `UserData.template_progress`, dropped for retired slots in `normalize_spare_slot`.
+
+**`store.py`** — `_load` catches `UnsupportedSchemaVersionError` *before* the generic
+`ValueError` branch, logs, and re-raises rather than quarantining. Corrupt files still
+quarantine exactly as before.
+
+**`templates.py`** (new) — `extract_candidate_entities`, `coerce_truthy`, and
+`TemplateWatcher`.
+
+**`mqtt.py`** — `completion_mode` (select), `completion_template` (text, `max: 255`) and
+`completion_duration` (number) added to `publish_slot`, `publish_config_state` and
+`_slot_entity_keys`.
+
+**`habit_tracker.py`** — `initialize` guards store construction, builds the watcher, and
+restores listeners via the deferred callback. `_evaluate_template` implements `instant`.
+`_set_completion` maintains progress and suppression. `_update_habit` handles the three
+new keys.
+
+**`apps.yaml`** — `template_evaluation_enabled: false` (cutover flag) and
+`template_eval_debounce_seconds: 2`.
+
+## Where the code deviates from Part A
+
+Read this section before trusting Part A's code snippets.
+
+1. **Entity filtering uses live state, not a regex-only list.** Part A implies the regex
+   result is used directly. In practice `extract_candidate_entities` returns *candidates*
+   (it cannot tell `sensor.steps` from `value.split`), and
+   `_rebuild_template_listeners` keeps only those where `self.get_state(name) is not None`.
+   No domain allowlist to maintain. Consequence: an entity that does not exist yet is
+   dropped and the slot logs "references no known entities".
+
+2. **`ENTITY_PATTERN` differs.** Part A used `\b([a-z_]{3,})\.([a-z0-9_]+)\b`. Shipped is
+   `(?<![\w.])([a-z_][a-z0-9_]*)\.([a-z0-9_]+)(?![\w.])`, so a dotted chain such as
+   `states.sensor.foo` yields nothing rather than a bogus `states.sensor`.
+
+3. **`coerce_truthy` returns `bool | None`, not `bool`.** `None` means "unrecognised", so
+   the caller logs once and falls back to `False`. Part A folded this into `False`.
+
+4. **`TemplateWatcher` has a different surface.** Part A said `arm` / `cancel` /
+   `cancel_all` / `release`. Shipped is `watch` / `unwatch` / `schedule` /
+   `cancel_scheduled` / `release` / `remove` / `cancel_all`. **It has no duration timer
+   methods yet** — Phase 3 must add them.
+
+5. **`_update_habit` snapshots and rolls back.** Not in Part A. Fields are mutated in
+   place but cross-field rules only run in `__post_init__` afterwards, so a rejected
+   command would otherwise leave the in-memory config dirty for a later save to persist.
+   `snapshot = config.to_dict()` is taken up front and restored on `ValueError`.
+
+6. **Midnight does not clear `template_progress`.** Part A said it should. Instead
+   `_template_progress()` replaces any record whose `day` differs from today, so rollover
+   is lazy and automatic — including `suppressed_day`. `_midnight_rollover` only schedules
+   a re-evaluation of event-driven slots.
+
+7. **Observability landed early, partially.** `watched_entities` and `completion_mode` are
+   published on the slot's `name` attributes now. The `binary_sensor.condition` and
+   `sensor.condition_progress` entities from Part A's Phase 5 are **not** built.
+
+8. **`TIME_TICK_ENTITY` is already wired.** `_rebuild_template_listeners` appends
+   `sensor.time` for duration modes today, even though duration modes do not yet act.
+
+9. **Phase 0 was larger than Part A described.** It also added the non-destructive refusal
+   in `store.py` and the inert-on-failure guard in `initialize`. Both matter: without them
+   a future-version store is renamed to `.invalid-*` and then overwritten by an empty one.
+
+## Next up — Phase 3 (`continuous`)
+
+1. Add duration timers to `TemplateWatcher` (`arm_duration` / `cancel_duration`), keyed
+   `(user, slot)`, mirroring `ReminderManager`.
+2. In `_evaluate_template`, branch on `CompletionMode.CONTINUOUS`:
+   - rising edge → `truthy_since = now`, arm for `completion_duration_minutes * 60`
+   - falling edge → clear `truthy_since`, cancel timer
+   - timer fires → **re-render to confirm still truthy**, then `_set_completion(..., 1)`
+3. Restart recovery in `_restore_templates`: keep `accumulated_seconds`, discard the
+   in-flight `truthy_since` gap, re-stamp `truthy_since = now` if currently truthy.
+4. `terminate` already calls `templates.cancel_all()` — make sure it cancels duration
+   timers too once they exist.
+
+The re-render on timer fire is the safety net for a missed falling edge. Do not skip it.
+
+Then Phase 4 (`summed` — bank on falling edge, arm for `target − accumulated`) and
+Phase 5 (observability entities, README, drop the cutover flag).
+
+## Environment gotchas
+
+These cost time if rediscovered from scratch.
+
+- **The sandbox runs Python 3.10; the project targets 3.12.** `StrEnum`, `typing.Self`
+  and `datetime.UTC` are all 3.11+. There is no network access to install a newer
+  interpreter (`uv python install` fails at the proxy).
+- **`.venv` is macOS-only.** Its shebangs point at a macOS interpreter, so
+  `.venv/bin/basedpyright` and friends cannot run from a Linux sandbox.
+- **ruff and basedpyright have not been run on any of this work.** No network to install
+  them. Everything parses and sits inside the 90-char limit, but
+  **`pre-commit run --all-files` is still outstanding** and is the first thing to do.
+  `templates.py` is a new file and its `Protocol` definitions are the most likely place
+  strict mode complains.
+- Relevant lint config: `line-length = 90`, `select = ["ALL"]` with `ANN`, `EM`, `BLE`,
+  `TRY003`, `D107` ignored, `pydocstyle` google convention, `max-args = 10`.
+
+## Verification approach
+
+There are **no tests in the repo, deliberately** — the owner considers unit tests overkill
+here and that decision stands. Verification was done with throwaway scripts held outside
+the repo. To recreate them:
+
+- Shim the three 3.11+ stdlib names before importing (`enum.StrEnum` as
+  `class S(str, Enum)` with `__str__` returning the value, `typing.Self = Any`,
+  `datetime.UTC = timezone.utc`).
+- Stub `paho.mqtt.client` / `paho.mqtt.enums` and `appdaemon.plugins.hass.hassapi.Hass`
+  in `sys.modules` — neither is installed and neither is exercised.
+- Subclass `HabitTracker` and override only the AppDaemon surface (`log`, `error`,
+  `datetime`, `get_state`, `render_template`, `listen_state`, `cancel_listen_state`,
+  `run_in`, `cancel_timer`). This drives the shipped `_evaluate_template` rather than a
+  reimplementation, which is the whole point.
+
+What was covered: v1→v2 migration against a populated store, chained migrations, refusal
+without quarantine, corrupt-still-quarantines, backup recovery, all five config
+validation rejections, `TemplateProgress` round-trip and retirement, entity extraction
+edge cases, the full `coerce_truthy` table, instant-mode rising edge, no double
+completion, un-tick suppression and next-day reset, render exceptions, unusable values,
+manual/disabled inertness, and listener resolution.
+
+## Deployment notes
+
+- **Back up `store.json` before first deploy of v2.** The first save rewrites it, and
+  Phase 0 code would then refuse to start (safely — it will not touch the file).
+- Deploy with `template_evaluation_enabled: false` first. Confirm the three new entities
+  appear per habit slot and that nothing fires.
+- Only then flip the flag, starting with one `instant` habit pointed at something you can
+  toggle by hand.
+
+## Open questions still unresolved
+
+Carried over from Part A, none answered yet:
+
+- `instant` with a persistently truthy template re-completes at 00:00 every day. Probably
+  wanted, but it has not been confirmed.
+- No flapping hysteresis. A template oscillating around a threshold will reset
+  `continuous` indefinitely. Becomes real in Phase 3.
+- Countable habits are excluded from duration modes and cannot currently be driven by a
+  template at all.
+
+## Unrelated repo state
+
+At time of writing there were untracked `apps/chatgpt/`, `apps/openai/` and
+`tools/chatgpt_usage/` directories, unrelated to this work. The working tree also gets
+committed externally mid-session at times, so check `git log` before assuming your
+changes are uncommitted.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -46,7 +46,6 @@ Each user also receives:
 - `select.<user>_mood_today`
 - `text.<user>_mood_note`
 - `sensor.<user>_mood_streak`
-- `button.<user>_habit_test_reminder`
 
 ## Persistence
 
@@ -94,8 +93,6 @@ run too close to midnight.
 
 Notifications are sent through the user's configured `script.notify_*` script. Their
 action button either marks a binary habit complete or increments a countable habit.
-The per-user test button sends a reminder for the lowest-numbered configured,
-incomplete habit.
 
 At local midnight, current values reset while historical completions remain available
 for streak calculations. Mood and mood notes reset at the same time.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -48,6 +48,7 @@ Each user also receives:
 - `text.<user>_mood_note`
 - `sensor.<user>_mood_streak`
 - `time.<user>_mood_reminder_time` (daily template for the first fire)
+- `switch.<user>_mood_reminders` (enable/disable mood reminder notifications)
 - `datetime.<user>_mood_next_reminder` (editable absolute fire time)
 - `number.<user>_mood_repeat_count` and `number.<user>_mood_repeat_interval`
 
@@ -114,10 +115,11 @@ the timer.
 `reminders_enabled: false` still no-ops sends and does not arm timers.
 
 Mood reminders use the same durable `next_reminder` pattern with user-level
-entities (`mood_reminder_time`, `mood_next_reminder`, repeat count/interval). A
-mood reminder is skipped once today's mood is set, and the pending chain is
-cleared at that point. Midnight re-seeds an incomplete mood check-in for the new
-day.
+entities (`mood_reminders`, `mood_reminder_time`, `mood_next_reminder`, repeat
+count/interval). Turning `mood_reminders` off clears any pending mood timer.
+A mood reminder is also skipped once today's mood is set, and the pending chain
+is cleared at that point. Midnight re-seeds an incomplete mood check-in for the
+new day when reminders are enabled.
 
 Notifications are sent through the user's configured `script.notify_*` script. Their
 action button either marks a binary habit complete or increments a countable habit.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -66,9 +66,22 @@ Habit completion history is stored by local calendar date:
 - Countable habits store their daily count.
 - A count greater than zero counts as completion for streak purposes.
 
-With a seven-day minimum, streaks require daily completion. Lower settings allow gaps
-inside a week and continue across consecutive prior weeks that meet the configured
-minimum.
+With a seven-day minimum, streaks require daily completion. Lower settings use a
+**weekly-grace** model that is intentionally different from the legacy SQL streak
+sensors:
+
+- The current/anchor week contributes every calendar day from Monday through the
+  anchor once the anchor day itself is complete (individual gaps earlier in that
+  week do not truncate the count).
+- Each prior week that meets `streak_min_days_per_week` adds a full 7 days, even
+  if some days in that week were missed.
+- The legacy SQL `first_incomplete_day` CTE broke the streak on any individually
+  missed day regardless of week totals, which made weekly grace almost a no-op.
+  The AppDaemon algorithm treats the threshold as real weekly grace instead.
+
+Default configs use `streak_min_days_per_week = 7`, so most habits stay on the
+strict daily path and are unaffected. Numbers can change on cutover only for habits
+that already used a lower threshold.
 
 ## Reminders
 

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -16,7 +16,7 @@ change.
 - `models.py` defines the persisted schema and calculates habit and mood streaks.
 - `mqtt.py` publishes Home Assistant MQTT discovery, state, attributes, and
   availability.
-- `reminders.py` owns daily schedules and cancellable repeat-reminder timers.
+- `reminders.py` owns absolute next-fire timers per habit slot.
 - `store.py` writes the versioned JSON store atomically and keeps a backup plus an
   append-only completion audit log.
 
@@ -30,7 +30,8 @@ Each slot exposes:
 - A text entity for the habit name.
 - A select entity for `binary` or `countable` tracking.
 - A switch for a binary habit, or a number for a countable habit.
-- A reminder-time entity.
+- A reminder-time entity (daily template for the first fire).
+- A next-reminder datetime entity (editable absolute fire time).
 - Repeat count and interval controls.
 - A minimum-days-per-week streak control.
 - An AI-reminder switch.
@@ -84,18 +85,37 @@ that already used a lower threshold.
 
 ## Reminders
 
-Configured habits receive a daily AppDaemon schedule. A reminder is skipped if the
-habit is already complete for the current day.
+Each configured habit has a durable `datetime.<user>_habit_<slot>_next_reminder`
+entity. That datetime is the editable source of truth for when the next notification
+fires. The `time.<user>_habit_<slot>_reminder_time` entity is only the recurring daily
+template used to seed `next_reminder`.
 
-Repeat reminders are scheduled one at a time and are cancelled when the habit is
-completed, renamed, deleted, or changes type. A repeat is not scheduled if it would
-run too close to midnight.
+Attempt metadata (`fire_at`, reminder index, final index) is persisted in
+`store.json` under `pending_reminders`, so AppDaemon restarts can restore the same
+chain. Editing `next_reminder` in Home Assistant updates the stored fire time, keeps
+the current indices, cancels the in-memory timer, and reschedules. Past times fire
+almost immediately.
+
+Seeding happens on midnight rollover and when a habit becomes configured: if the habit
+is incomplete and has no pending reminder, `next_reminder` is set to today at
+`reminder_time` (or now if that time has already passed), with `next_index=1`. Changing
+`reminder_time` only retargets a pending **first** reminder for today; mid-chain
+repeats are left alone.
+
+When a reminder fires, the app skips completed habits, sends the notification, then
+either advances `next_reminder` by the repeat interval (while under the midnight
+cutoff) or clears the pending chain. Completion, rename, delete, type change, or end
+of chain clears the store entry, publishes an empty/`None` datetime state, and cancels
+the timer.
+
+`reminders_enabled: false` still no-ops sends and does not arm timers.
 
 Notifications are sent through the user's configured `script.notify_*` script. Their
 action button either marks a binary habit complete or increments a countable habit.
 
 At local midnight, current values reset while historical completions remain available
-for streak calculations. Mood and mood notes reset at the same time.
+for streak calculations. Mood and mood notes reset at the same time. Pending reminder
+chains are cleared and incomplete habits are re-seeded for the new day.
 
 ## AI reminders
 

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -1,0 +1,159 @@
+# Habit and Mood Tracker
+
+This AppDaemon app provides a GUI-managed habit and mood tracker for Home
+Assistant. AppDaemon owns the entities through MQTT discovery, schedules reminders,
+records completions, calculates streaks, and persists everything across restarts.
+
+Habits are not defined in Python or `apps.yaml`. A user creates a habit by naming the
+spare `text.<user>_habit_<slot>_name` entity in Home Assistant. The app immediately
+creates another spare slot, so adding habits never requires a code or configuration
+change.
+
+## Structure
+
+- `habit_tracker.py` coordinates AppDaemon callbacks, MQTT commands, reminders,
+  completion actions, daily rollover, legacy migration, and AI context.
+- `models.py` defines the persisted schema and calculates habit and mood streaks.
+- `mqtt.py` publishes Home Assistant MQTT discovery, state, attributes, and
+  availability.
+- `reminders.py` owns daily schedules and cancellable repeat-reminder timers.
+- `store.py` writes the versioned JSON store atomically and keeps a backup plus an
+  append-only completion audit log.
+
+## Home Assistant entities
+
+Each user has one MQTT device containing their habits and mood entities. Habit entity
+IDs use stable numbered slots so changing a habit's name does not change its identity.
+
+Each slot exposes:
+
+- A text entity for the habit name.
+- A select entity for `binary` or `countable` tracking.
+- A switch for a binary habit, or a number for a countable habit.
+- A reminder-time entity.
+- Repeat count and interval controls.
+- A minimum-days-per-week streak control.
+- An AI-reminder switch.
+- Configurable icons for complete, incomplete, active, and zero states.
+- A streak sensor with completion age and 28-day completion rate attributes.
+
+The app maintains exactly one unnamed spare slot per user. Clearing a habit's name
+deletes that habit and its completion history. Unused discovery entities are retired
+from Home Assistant automatically.
+
+Each user also receives:
+
+- `select.<user>_mood_today`
+- `text.<user>_mood_note`
+- `sensor.<user>_mood_streak`
+- `button.<user>_habit_test_reminder`
+
+## Persistence
+
+The default data directory is:
+
+```text
+/homeassistant/.appdaemon/habits
+```
+
+`store.json` is the source of truth. Writes are atomic, the previous valid file is
+retained as `store.json.backup`, and invalid files are quarantined. Completion changes
+are additionally appended to `completions.jsonl`.
+
+Habit completion history is stored by local calendar date:
+
+- Binary habits store `1` when complete.
+- Countable habits store their daily count.
+- A count greater than zero counts as completion for streak purposes.
+
+With a seven-day minimum, streaks require daily completion. Lower settings allow gaps
+inside a week and continue across consecutive prior weeks that meet the configured
+minimum.
+
+## Reminders
+
+Configured habits receive a daily AppDaemon schedule. A reminder is skipped if the
+habit is already complete for the current day.
+
+Repeat reminders are scheduled one at a time and are cancelled when the habit is
+completed, renamed, deleted, or changes type. A repeat is not scheduled if it would
+run too close to midnight.
+
+Notifications are sent through the user's configured `script.notify_*` script. Their
+action button either marks a binary habit complete or increments a countable habit.
+The per-user test button sends a reminder for the lowest-numbered configured,
+incomplete habit.
+
+At local midnight, current values reset while historical completions remain available
+for streak calculations. Mood and mood notes reset at the same time.
+
+## AI reminders
+
+When a habit's AI-reminder switch is enabled, the app calls the configured
+`ai_task` entity and asks it for a short reminder. Context can include:
+
+- Current streak, completion age, and recent completion rate.
+- Mood and mood note.
+- Broad location category derived from Home Assistant labels.
+- Calendar availability for the next eight hours.
+- Workday, current activity, steps, and exercise-bike time.
+- Weather and remaining daylight.
+- Whether this is the first, repeated, or final reminder.
+
+Unavailable context is omitted. If AI generation fails or returns an empty response,
+the app sends a deterministic fallback reminder.
+
+This implementation ports the behavior from the legacy Home Assistant
+`script.habit_send_reminder`. AppDaemon becomes the source of truth after cutover;
+the legacy script is not called or retained, so reminder scheduling, context
+collection, AI generation, fallback handling, and notification delivery remain one
+cohesive workflow.
+
+## Configuration
+
+The app is registered in `apps/apps.yaml`. Its configuration contains only
+installation-level concerns:
+
+- Users and their notification/dashboard settings.
+- Context entity IDs and label names.
+- MQTT connection and discovery settings.
+- Persistence directory.
+- AI Task entity.
+- The `reminders_enabled` cutover flag.
+
+No individual habit belongs in `apps.yaml`.
+
+`reminders_enabled` is intentionally `false` during migration so the existing Home
+Assistant automations and AppDaemon cannot send duplicate reminders. Enable it only
+after the MQTT entities, migrated habits, test notifications, and dashboards have
+been verified.
+
+## Legacy migration
+
+When no store exists, the app performs a one-time import of the old numbered
+`input_*` helpers. It imports configured names, types, icons, reminder settings, AI
+settings, current completion state, and mood values. It then marks bootstrap complete
+in the store and does not import again.
+
+The old Home Assistant helpers and automations must remain available for this first
+startup. Remove them only after confirming that the imported MQTT entities are
+correct.
+
+AppDaemon uses its own slot-based mobile action IDs during the overlap period. This
+prevents both the legacy Home Assistant action automation and AppDaemon from handling
+the same countable-habit action and incrementing it twice. The legacy notification
+action automations are removed during final cutover.
+
+## Availability and recovery
+
+All discovered entities share an MQTT last-will availability topic. If AppDaemon or
+its MQTT connection stops, the entities become unavailable instead of displaying
+stale state.
+
+For troubleshooting, check:
+
+1. The AppDaemon log for configuration, MQTT, calendar, or AI errors.
+2. MQTT connectivity and the retained topics below `appdaemon/habits`.
+3. The contents and permissions of the persistence directory.
+4. That the configured Home Assistant labels and context entities exist.
+5. That `reminders_enabled` has the intended value for the current migration stage.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -139,9 +139,8 @@ Context can include:
 - Mood and mood note (habit reminders).
 - Broad location category derived from Home Assistant labels.
 - Calendar availability for the next eight hours.
-- Workday, current activity, and steps.
-- Weather and remaining daylight.
-- Whether this is the first, repeated, or final reminder.
+- Workday, current activity, and weather (habits).
+- Local date.
 
 Unavailable context is omitted. If AI generation fails or returns an empty response,
 the app sends a deterministic fallback reminder.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -47,6 +47,9 @@ Each user also receives:
 - `select.<user>_mood_today`
 - `text.<user>_mood_note`
 - `sensor.<user>_mood_streak`
+- `time.<user>_mood_reminder_time` (daily template for the first fire)
+- `datetime.<user>_mood_next_reminder` (editable absolute fire time)
+- `number.<user>_mood_repeat_count` and `number.<user>_mood_repeat_interval`
 
 ## Persistence
 
@@ -109,6 +112,12 @@ of chain clears the store entry, publishes an empty/`None` datetime state, and c
 the timer.
 
 `reminders_enabled: false` still no-ops sends and does not arm timers.
+
+Mood reminders use the same durable `next_reminder` pattern with user-level
+entities (`mood_reminder_time`, `mood_next_reminder`, repeat count/interval). A
+mood reminder is skipped once today's mood is set, and the pending chain is
+cleared at that point. Midnight re-seeds an incomplete mood check-in for the new
+day.
 
 Notifications are sent through the user's configured `script.notify_*` script. Their
 action button either marks a binary habit complete or increments a countable habit.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -130,11 +130,13 @@ chains are cleared and incomplete habits are re-seeded for the new day.
 
 ## AI reminders
 
-When a habit's AI-reminder switch is enabled, the app calls the configured
-`ai_task` entity and asks it for a short reminder. Context can include:
+When a habit's AI-reminder switch is enabled, or when a mood reminder fires, the
+app calls the configured `ai_task` entity and asks it for a short reminder.
+Context can include:
 
-- Current streak, completion age, and recent completion rate.
-- Mood and mood note.
+- Current streak, completion age, and recent completion rate (habits).
+- Mood streak and that today's mood is still unset (mood reminders).
+- Mood and mood note (habit reminders).
 - Broad location category derived from Home Assistant labels.
 - Calendar availability for the next eight hours.
 - Workday, current activity, and steps.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -125,19 +125,12 @@ No individual habit belongs in `apps.yaml`.
 
 `reminders_enabled` is intentionally `false` during migration so the existing Home
 Assistant automations and AppDaemon cannot send duplicate reminders. Enable it only
-after the MQTT entities, migrated habits, test notifications, and dashboards have
-been verified.
+after the MQTT entities, manually configured habits, test notifications, and
+dashboards have been verified.
 
-## Legacy migration
-
-When no store exists, the app performs a one-time import of the old numbered
-`input_*` helpers. It imports configured names, types, icons, reminder settings, AI
-settings, current completion state, and mood values. It then marks bootstrap complete
-in the store and does not import again.
-
-The old Home Assistant helpers and automations must remain available for this first
-startup. Remove them only after confirming that the imported MQTT entities are
-correct.
+Habits are configured in the GUI after deploy — there is no import from the old
+numbered `input_*` helpers. Keep the legacy helpers/automations until the new
+entities and reminders are verified, then remove them at cutover.
 
 AppDaemon uses its own slot-based mobile action IDs during the overlap period. This
 prevents both the legacy Home Assistant action automation and AppDaemon from handling

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -140,7 +140,7 @@ Context can include:
 - Broad location category derived from Home Assistant labels.
 - Calendar availability for the next eight hours.
 - Workday, current activity, and weather (habits).
-- Local date.
+- Soft local time context (weekday, month, and clock time — not a full date).
 
 Unavailable context is omitted. If AI generation fails or returns an empty response,
 the app sends a deterministic fallback reminder.

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -106,7 +106,7 @@ When a habit's AI-reminder switch is enabled, the app calls the configured
 - Mood and mood note.
 - Broad location category derived from Home Assistant labels.
 - Calendar availability for the next eight hours.
-- Workday, current activity, steps, and exercise-bike time.
+- Workday, current activity, and steps.
 - Weather and remaining daylight.
 - Whether this is the first, repeated, or final reminder.
 

--- a/apps/habit/__init__.py
+++ b/apps/habit/__init__.py
@@ -1,0 +1,1 @@
+"""Habit tracking AppDaemon package."""

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -343,9 +343,10 @@ class HabitTracker(hass.Hass):
             self._rebuild_template_listeners(user, slot)
             self._schedule_evaluation(user, slot)
         added_spare, retired = self._normalize_user_slots(user)
+        config = data.habits.get(slot)
         self.store.save()
         if self.mqtt is not None:
-            if slot in data.habits:
+            if config is not None:
                 self.mqtt.publish_slot(user, config)
                 self._publish_habit_state(user, slot)
                 self._publish_next_reminder(user, slot)

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -54,7 +54,6 @@ REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
     "workday_entity",
     "activity_entity",
     "steps_entity",
-    "exercise_entity",
     "weather_entity",
     "sun_entity",
 )
@@ -526,10 +525,6 @@ class HabitTracker(hass.Hass):
                 "Steps so far today",
                 self._numeric_state(str(user_config["steps_entity"]), integer=True),
             ),
-            (
-                "Exercise bike active minutes",
-                self._bike_minutes(str(user_config["exercise_entity"])),
-            ),
             ("Weather", self._weather_summary(str(user_config["weather_entity"]))),
             (
                 "Daylight remaining minutes",
@@ -653,12 +648,6 @@ class HabitTracker(hass.Hass):
         except (TypeError, ValueError):
             return ""
         return int(numeric) if integer else numeric
-
-    def _bike_minutes(self, entity_id: str) -> str | float:
-        seconds = self._numeric_state(entity_id)
-        return (
-            "" if not isinstance(seconds, int | float) else round(float(seconds) / 60, 1)
-        )
 
     def _weather_summary(self, entity_id: str) -> str:
         condition = self._state_value(entity_id)

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -70,7 +70,7 @@ class HabitTracker(hass.Hass):
     mqtt: HabitMqtt | None
 
     def initialize(self) -> None:
-        """Load disk state, bootstrap legacy helpers, and start integrations."""
+        """Load disk state and start integrations."""
         self.users = tuple(str(user).lower() for user in self.args.get("users", ()))
         if not self.users:
             self.error("At least one user is required")
@@ -90,8 +90,6 @@ class HabitTracker(hass.Hass):
             ),
             self.users,
         )
-        if not self.store.existed and not self.store.data.bootstrap_complete:
-            self._bootstrap_legacy_helpers()
         self._startup_retired: dict[str, tuple[int, ...]] = {}
         for user in self.users:
             _, retired = self._normalize_user_slots(user)
@@ -766,101 +764,6 @@ class HabitTracker(hass.Hass):
             with suppress(AttributeError):
                 self.reminders.remove(user, slot)
         return added_spare, retired
-
-    def _bootstrap_legacy_helpers(self) -> None:
-        for user in self.users:
-            data = self.store.data.users[user]
-            data.habits.clear()
-            names = self.get_state("input_text") or {}
-            if not isinstance(names, dict):
-                continue
-            prefix = f"{user}_habit_"
-            slots: set[tuple[HabitType, int]] = set()
-            for entity_id in names:
-                object_id = str(entity_id).removeprefix("input_text.")
-                if not object_id.startswith(prefix) or not object_id.endswith("_name"):
-                    continue
-                middle = object_id[len(prefix) : -len("_name")]
-                habit_type_raw, _, slot_raw = middle.rpartition("_")
-                with suppress(ValueError):
-                    slots.add((HabitType(habit_type_raw), int(slot_raw)))
-            for habit_type, old_slot in sorted(
-                slots,
-                key=lambda item: (item[0], item[1]),
-            ):
-                old_prefix = f"{user}_habit_{habit_type}_{old_slot}"
-                name = self._legacy_state(f"input_text.{old_prefix}_name")
-                if not name:
-                    continue
-                new_slot = max(data.habits, default=0) + 1
-                config = HabitConfig(
-                    slot=new_slot,
-                    name=name,
-                    habit_type=habit_type,
-                    reminder_time=self._legacy_state(
-                        f"input_datetime.{old_prefix}_reminder_time",
-                        "09:00:00",
-                    ),
-                    repeat_count=self._legacy_int(
-                        f"input_number.{old_prefix}_repeat_reminder_count",
-                        0,
-                    ),
-                    repeat_interval_minutes=self._legacy_int(
-                        f"input_number.{old_prefix}_repeat_reminder_interval",
-                        60,
-                    ),
-                    streak_min_days_per_week=self._legacy_int(
-                        f"input_number.{old_prefix}_streak_min_days_per_week",
-                        7,
-                    ),
-                    ai_enabled=self._legacy_state(
-                        f"input_boolean.{old_prefix}_ai_reminder",
-                    )
-                    == "on",
-                    icon_on=self._legacy_state(
-                        f"input_text.{old_prefix}_icon_on",
-                        "mdi:check-circle",
-                    ),
-                    icon_active=self._legacy_state(
-                        f"input_text.{old_prefix}_icon_active",
-                        "mdi:counter",
-                    ),
-                    icon_off=self._legacy_state(
-                        f"input_text.{old_prefix}_icon_off",
-                        "mdi:circle-outline",
-                    ),
-                    icon_zero=self._legacy_state(
-                        f"input_text.{old_prefix}_icon_zero",
-                        "mdi:counter",
-                    ),
-                )
-                data.habits[new_slot] = config
-                state_domain = (
-                    "input_boolean" if habit_type is HabitType.BINARY else "input_number"
-                )
-                current = self._legacy_state(f"{state_domain}.{old_prefix}", "0")
-                count = 1 if current == "on" else int(float(current))
-                if count > 0:
-                    data.completions[new_slot] = {
-                        self.datetime().date().isoformat(): count,
-                    }
-            data.mood_today = self._legacy_state(
-                f"input_select.{user}_mood_today",
-                "Not Set",
-            )
-            data.mood_note = self._legacy_state(f"input_text.{user}_mood_note")
-        self.store.data.bootstrap_complete = True
-
-    def _legacy_state(self, entity_id: str, default: str = "") -> str:
-        value = self.get_state(entity_id)
-        return default if value in INVALID_STATES else str(value)
-
-    def _legacy_int(self, entity_id: str, default: int) -> int:
-        value = self._legacy_state(entity_id)
-        try:
-            return int(float(value))
-        except ValueError:
-            return default
 
     def _validate_config(self) -> bool:  # noqa: C901, PLR0912
         errors: list[str] = []

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -38,6 +38,7 @@ Requirements:
 - Return only the notification message text
 - One or two short sentences maximum
 - Mention the habit name naturally
+- Do not address the recipient by name or with a personal greeting
 - You may mention streak, mood, completion rate, or that this is a repeat reminder
   when that context is useful
 - Use location only when it materially affects whether the habit is feasible right
@@ -48,6 +49,23 @@ Requirements:
 - Use weather and daylight only when they materially affect an outdoor habit
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
+MOOD_AI_INSTRUCTIONS: Final[str] = """Write one short mood check-in reminder notification
+message.
+
+Tone: neutral, positive, and encouraging. Do not be sarcastic, preachy, or overly
+casual. Do not invent facts.
+
+Requirements:
+- Return only the notification message text
+- One or two short sentences maximum
+- Ask the recipient to log how they are feeling today
+- Do not address the recipient by name or with a personal greeting
+- You may mention mood streak or that this is a repeat reminder when useful
+- If the user is in a meeting or has only a short free window, suggest a realistic
+  later time instead of interrupting them
+- Do not name specific places, addresses, or coordinates
+- Do not include markdown, emojis, quotes, or a title"""
+MOOD_FALLBACK_MESSAGE: Final[str] = "Don't forget to log how you're feeling today."
 
 REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
     "notify_script",
@@ -813,7 +831,7 @@ class HabitTracker(hass.Hass):
                 "script/turn_on",
                 entity_id=user_config["notify_script"],
                 variables={
-                    "title": "Habit Reminder",
+                    "title": config.name,
                     "message": message,
                     "notification_id": f"{user}_habit_{slot}_reminder",
                     "mobile_notification_icon": "mdi:checkbox-marked-circle-outline",
@@ -858,25 +876,9 @@ class HabitTracker(hass.Hass):
             self._clear_mood_pending(user)
             self.store.save()
             return
-        user_config = self._user_config(user)
-        try:
-            self.call_service(
-                "script/turn_on",
-                entity_id=user_config["notify_script"],
-                variables={
-                    "title": "Mood Reminder",
-                    "message": "Don't forget to log how you're feeling today.",
-                    "notification_id": f"{user}_mood_reminder",
-                    "mobile_notification_icon": "mdi:emoticon-outline",
-                    "url": user_config["dashboard_url"],
-                    "actions": "[]",
-                },
-            )
-        except Exception as error:
-            self.error("Mood reminder notification failed for %s: %s", user, error)
+        now = self._aware_now()
         last_index = final_index or data.mood_repeat_count + 1
         next_index = reminder_index + 1
-        now = self._aware_now()
         if next_index <= last_index and repeat_fits_before_midnight(
             now,
             data.mood_repeat_interval_minutes,
@@ -894,36 +896,79 @@ class HabitTracker(hass.Hass):
         self.store.save()
         self._publish_mood_next_reminder(user)
 
+        message = self._ai_mood_message(user, reminder_index) or MOOD_FALLBACK_MESSAGE
+        self.log("Sending mood reminder for %s (attempt %s)", user, reminder_index)
+        self._notify_mood(user, message)
+
+    def _notify_mood(self, user: str, message: str) -> None:
+        user_config = self._user_config(user)
+        try:
+            self.call_service(
+                "script/turn_on",
+                entity_id=user_config["notify_script"],
+                variables={
+                    "title": "Mood",
+                    "message": message,
+                    "notification_id": f"{user}_mood_reminder",
+                    "mobile_notification_icon": "mdi:emoticon-outline",
+                    "url": user_config["dashboard_url"],
+                    "actions": "[]",
+                },
+            )
+        except Exception as error:
+            self.error("Mood reminder notification failed for %s: %s", user, error)
+
     def _ai_message(
         self,
         user: str,
         config: HabitConfig,
         reminder_index: int,
     ) -> str | None:
+        return self._generate_ai_message(
+            task_name=(f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"),
+            instructions=AI_INSTRUCTIONS,
+            context=self._ai_context(user, config, reminder_index),
+            kind="habit",
+        )
+
+    def _ai_mood_message(self, user: str, reminder_index: int) -> str | None:
+        return self._generate_ai_message(
+            task_name=f"mood reminder {user}",
+            instructions=MOOD_AI_INSTRUCTIONS,
+            context=self._ai_mood_context(user, reminder_index),
+            kind="mood",
+        )
+
+    def _generate_ai_message(
+        self,
+        *,
+        task_name: str,
+        instructions: str,
+        context: str,
+        kind: str,
+    ) -> str | None:
         try:
-            context = self._ai_context(user, config, reminder_index)
             # Pass entity_id inside service_data — AppDaemon's top-level entity_id
             # kwarg is moved into target and HA rejects that shape for ai_task.
             response = self.call_service(
                 "ai_task/generate_data",
                 service_data={
                     "entity_id": self.args["ai_task_entity"],
-                    "task_name": (
-                        f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"
-                    ),
-                    "instructions": f"{AI_INSTRUCTIONS}\n\nContext:\n{context}",
+                    "task_name": task_name,
+                    "instructions": f"{instructions}\n\nContext:\n{context}",
                 },
                 return_response=True,
                 hass_timeout=180,
                 timeout=180,
             )
         except Exception as error:
-            self.error("AI habit reminder failed: %s", error)
+            self.error("AI %s reminder failed: %s", kind, error)
             return None
         message = _ai_response_text(response)
         if message is None:
             self.error(
-                "AI habit reminder returned no usable text (response=%r)",
+                "AI %s reminder returned no usable text (response=%r)",
+                kind,
                 response,
             )
         return message
@@ -951,7 +996,6 @@ class HabitTracker(hass.Hass):
             else f"repeat reminder {reminder_index} of {repeat_total}"
         )
         pairs: list[tuple[str, object]] = [
-            ("User", user.title()),
             ("Habit name", config.name),
             ("Habit type", config.habit_type),
             ("Current streak days", stats.streak),
@@ -979,6 +1023,41 @@ class HabitTracker(hass.Hass):
             (
                 "Daylight remaining minutes",
                 self._daylight_minutes(str(user_config["sun_entity"]), now),
+            ),
+            ("Local time", now.strftime("%H:%M")),
+            ("Reminder attempt", attempt),
+        ]
+        return "\n".join(
+            f"- {label}: {value}"
+            for label, value in pairs
+            if value not in INVALID_STATES and value not in {"Not Set", -1}
+        )
+
+    def _ai_mood_context(self, user: str, reminder_index: int) -> str:
+        data = self.store.data.users[user]
+        user_config = self._user_config(user)
+        now = self._aware_now()
+        repeat_total = data.mood_repeat_count + 1
+        attempt = (
+            "first reminder today"
+            if reminder_index == 1
+            else f"final reminder today (attempt {reminder_index})"
+            if reminder_index >= repeat_total
+            else f"repeat reminder {reminder_index} of {repeat_total}"
+        )
+        pairs: list[tuple[str, object]] = [
+            ("Mood today", data.mood_today),
+            (
+                "Mood streak days",
+                calculate_mood_streak(data.mood_history, today=now.date()),
+            ),
+            ("Location category", self._location_category(user_config)),
+            ("Calendar availability", self._calendar_availability(user, now)),
+            (
+                "Workday",
+                "yes"
+                if self.get_state(str(user_config["workday_entity"])) == "on"
+                else "no",
             ),
             ("Local time", now.strftime("%H:%M")),
             ("Reminder attempt", attempt),

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -893,8 +893,8 @@ class HabitTracker(hass.Hass):
             self.log("Habit template completed %s slot %s", user, slot)
             # _set_completion persists and republishes.
             self._set_completion(user, slot, 1)
-            return
-        self.store.save()
+        else:
+            self.store.save()
 
     def _is_complete_today(self, user: str, slot: int) -> bool:
         return (
@@ -1192,7 +1192,7 @@ class HabitTracker(hass.Hass):
                 self._state_value(str(user_config["activity_entity"])),
             ),
             ("Weather", self._weather_summary(str(user_config["weather_entity"]))),
-            ("Local date", _local_date_label(now)),
+            ("Now", _local_now_label(now)),
         ]
         return "\n".join(
             f"- {label}: {value}"
@@ -1218,7 +1218,7 @@ class HabitTracker(hass.Hass):
                 if self.get_state(str(user_config["workday_entity"])) == "on"
                 else "no",
             ),
-            ("Local date", _local_date_label(now)),
+            ("Now", _local_now_label(now)),
         ]
         return "\n".join(
             f"- {label}: {value}"
@@ -1508,14 +1508,12 @@ def _mqtt_bool(payload: str) -> bool:
     raise ValueError("expected an on/off value")
 
 
-def _local_date_label(value: datetime) -> str:
-    day = value.day
-    suffix = (
-        "th"
-        if 11 <= day % 100 <= 13  # noqa: PLR2004
-        else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")  # codespell:ignore nd
+def _local_now_label(value: datetime) -> str:
+    """Compact day/month/time for AI context without a calendar date."""
+    return (
+        f"It's a {value.strftime('%A')} in {value.strftime('%B')} "
+        f"and it's {value.strftime('%H:%M')}"
     )
-    return f"{value.strftime('%A')}, {day}{suffix} {value.strftime('%B %Y')}"
 
 
 def _service_result(response: object) -> dict[str, Any] | None:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -1015,7 +1015,7 @@ class HabitTracker(hass.Hass):
                 "Daylight remaining minutes",
                 self._daylight_minutes(str(user_config["sun_entity"]), now),
             ),
-            ("Local time", now.strftime("%H:%M")),
+            ("Local date", _local_date_label(now)),
             ("Reminder attempt", attempt),
         ]
         return "\n".join(
@@ -1050,7 +1050,7 @@ class HabitTracker(hass.Hass):
                 if self.get_state(str(user_config["workday_entity"])) == "on"
                 else "no",
             ),
-            ("Local time", now.strftime("%H:%M")),
+            ("Local date", _local_date_label(now)),
             ("Reminder attempt", attempt),
         ]
         return "\n".join(
@@ -1347,6 +1347,16 @@ def _mqtt_bool(payload: str) -> bool:
     if normalized in {"off", "false", "0"}:
         return False
     raise ValueError("expected an on/off value")
+
+
+def _local_date_label(value: datetime) -> str:
+    day = value.day
+    suffix = (
+        "th"
+        if 11 <= day % 100 <= 13  # noqa: PLR2004
+        else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")  # codespell:ignore nd
+    )
+    return f"{value.strftime('%A')}, {day}{suffix} {value.strftime('%B %Y')}"
 
 
 def _service_result(response: object) -> dict[str, Any] | None:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -15,12 +15,13 @@ from .models import (
     MOOD_OPTIONS,
     HabitConfig,
     HabitType,
+    PendingReminder,
     calculate_mood_streak,
     calculate_streak,
     normalize_spare_slot,
 )
 from .mqtt import HabitMqtt, MqttSettings
-from .reminders import ReminderManager
+from .reminders import ReminderManager, repeat_fits_before_midnight
 from .store import HabitStore
 
 INVALID_STATES: Final[frozenset[object]] = frozenset(
@@ -104,7 +105,7 @@ class HabitTracker(hass.Hass):
         )
         for user in self.users:
             self.run_daily(self._midnight_rollover, time(), user=user)
-        self._schedule_all()
+        self._restore_reminders()
         self.log("Habit tracker initialized for %s", ", ".join(self.users))
 
     def terminate(self) -> None:
@@ -177,6 +178,7 @@ class HabitTracker(hass.Hass):
             for config in self.store.data.users[user].habits.values():
                 self.mqtt.publish_slot(user, config)
                 self._publish_habit_state(user, config.slot)
+                self._publish_next_reminder(user, config.slot)
             self._publish_mood_state(user)
 
     def _handle_mqtt_command(self, topic: str, payload: str) -> None:
@@ -205,6 +207,7 @@ class HabitTracker(hass.Hass):
         config = data.habits[slot]
         old_name = config.name
         old_type = config.habit_type
+        old_reminder_time = config.reminder_time
         if key == "name":
             new_name = payload.strip()
             if len(new_name) > MAX_NAME_LENGTH:
@@ -212,11 +215,15 @@ class HabitTracker(hass.Hass):
             config.name = new_name
             if old_name.strip() and not new_name:
                 data.completions.pop(slot, None)
+                self._clear_pending(user, slot)
         elif key == "type":
             config.habit_type = HabitType(payload)
         elif key == "reminder_time":
             time.fromisoformat(payload)
             config.reminder_time = payload
+        elif key == "next_reminder":
+            self._override_next_reminder(user, slot, payload)
+            return
         elif key == "repeat_count":
             config.repeat_count = _bounded_int(payload, 0, 100)
         elif key == "repeat_interval":
@@ -240,19 +247,30 @@ class HabitTracker(hass.Hass):
             raise KeyError(key)
         config.__post_init__()
         if config.name != old_name or config.habit_type is not old_type:
-            self.reminders.cancel_repeats(user, slot)
-        self._reschedule(user, config)
+            self._clear_pending(user, slot)
+        if (
+            config.reminder_time != old_reminder_time
+            and config.configured
+            and (pending := data.pending_reminders.get(slot)) is not None
+            and pending.next_index == 1
+        ):
+            self._seed_next_reminder(user, config, force=True)
+        elif config.configured and slot not in data.pending_reminders:
+            self._seed_next_reminder(user, config)
         added_spare, retired = self._normalize_user_slots(user)
         self.store.save()
         if self.mqtt is not None:
             if slot in data.habits:
                 self.mqtt.publish_slot(user, config)
                 self._publish_habit_state(user, slot)
+                self._publish_next_reminder(user, slot)
             if added_spare is not None and added_spare != slot:
                 spare = data.habits[added_spare]
                 self.mqtt.publish_slot(user, spare)
                 self._publish_habit_state(user, added_spare)
+                self._publish_next_reminder(user, added_spare)
             for retired_slot in retired:
+                self._clear_pending(user, retired_slot)
                 self.mqtt.retire_slot(user, retired_slot)
 
     def _update_mood(self, user: str, key: str, payload: str) -> None:
@@ -280,10 +298,16 @@ class HabitTracker(hass.Hass):
             values[day] = count
         else:
             values.pop(day, None)
-        self.reminders.cancel_repeats(user, slot)
+        data = self.store.data.users[user]
+        config = data.habits[slot]
+        if count:
+            self._clear_pending(user, slot)
+        elif config.configured:
+            self._seed_next_reminder(user, config, force=True)
         self.store.append_completion_log(user, slot, day, count)
         self.store.save()
         self._publish_habit_state(user, slot)
+        self._publish_next_reminder(user, slot)
 
     def _publish_habit_state(self, user: str, slot: int) -> None:
         if self.mqtt is None:
@@ -350,18 +374,134 @@ class HabitTracker(hass.Hass):
             ),
         )
 
-    def _schedule_all(self) -> None:
+    def _restore_reminders(self) -> None:
         if not self.reminders_enabled:
             return
         for user, data in self.store.data.users.items():
-            for config in data.habits.values():
-                self._reschedule(user, config)
+            changed = False
+            for slot, config in list(data.habits.items()):
+                pending = data.pending_reminders.get(slot)
+                if not config.configured or self._is_complete_today(user, slot):
+                    if pending is not None:
+                        self._clear_pending(user, slot)
+                        changed = True
+                    continue
+                if pending is None:
+                    self._seed_next_reminder(user, config)
+                    changed = True
+                    continue
+                self._arm_pending(user, slot, pending)
+            if changed:
+                self.store.save()
+            for slot in data.habits:
+                self._publish_next_reminder(user, slot)
 
-    def _reschedule(self, user: str, config: HabitConfig) -> None:
-        if self.reminders_enabled and config.configured:
-            self.reminders.schedule_daily(user, config.slot, config.reminder_time)
+    def _seed_next_reminder(
+        self,
+        user: str,
+        config: HabitConfig,
+        *,
+        force: bool = False,
+    ) -> None:
+        if not self.reminders_enabled or not config.configured:
+            return
+        if self._is_complete_today(user, config.slot):
+            self._clear_pending(user, config.slot)
+            return
+        data = self.store.data.users[user]
+        if not force and config.slot in data.pending_reminders:
+            return
+        now = self.datetime()
+        fire_at = datetime.combine(
+            now.date(),
+            time.fromisoformat(config.reminder_time),
+            tzinfo=now.tzinfo,
+        )
+        fire_at = max(fire_at, now)
+        pending = PendingReminder(
+            fire_at=fire_at.isoformat(),
+            next_index=1,
+            final_index=config.repeat_count + 1,
+        )
+        data.pending_reminders[config.slot] = pending
+        self._arm_pending(user, config.slot, pending)
+        self._publish_next_reminder(user, config.slot)
+
+    def _override_next_reminder(self, user: str, slot: int, payload: str) -> None:
+        data = self.store.data.users[user]
+        config = data.habits[slot]
+        if not payload.strip() or payload.strip() == "None":
+            self._clear_pending(user, slot)
+            self.store.save()
+            self._publish_next_reminder(user, slot)
+            return
+        if not config.configured:
+            raise ValueError("habit is not configured")
+        fire_at = self._parse_fire_at(payload)
+        pending = data.pending_reminders.get(slot)
+        if pending is None:
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=1,
+                final_index=config.repeat_count + 1,
+            )
         else:
-            self.reminders.remove(user, config.slot)
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=pending.next_index,
+                final_index=pending.final_index,
+            )
+        data.pending_reminders[slot] = pending
+        self._arm_pending(user, slot, pending)
+        self.store.save()
+        self._publish_next_reminder(user, slot)
+
+    def _arm_pending(self, user: str, slot: int, pending: PendingReminder) -> None:
+        if not self.reminders_enabled:
+            self.reminders.cancel(user, slot)
+            return
+        now = self.datetime()
+        fire_at = self._parse_fire_at(pending.fire_at)
+        self.reminders.schedule_at(
+            user,
+            slot,
+            fire_at=fire_at,
+            reminder_index=pending.next_index,
+            final_index=pending.final_index,
+            now=now,
+        )
+
+    def _clear_pending(self, user: str, slot: int) -> None:
+        self.reminders.cancel(user, slot)
+        self.store.data.users[user].pending_reminders.pop(slot, None)
+        self._publish_next_reminder(user, slot)
+
+    def _publish_next_reminder(self, user: str, slot: int) -> None:
+        if self.mqtt is None:
+            return
+        pending = self.store.data.users[user].pending_reminders.get(slot)
+        payload = pending.fire_at if pending is not None else "None"
+        self.mqtt.publish(
+            f"{self.mqtt.topic(f'{user}/{slot}')}/next_reminder/state",
+            payload,
+        )
+
+    def _is_complete_today(self, user: str, slot: int) -> bool:
+        return (
+            self.store.data.users[user]
+            .completions.get(slot, {})
+            .get(self.datetime().date().isoformat(), 0)
+            > 0
+        )
+
+    def _parse_fire_at(self, value: str) -> datetime:
+        fire_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        now = self.datetime()
+        if fire_at.tzinfo is None and now.tzinfo is not None:
+            return fire_at.replace(tzinfo=now.tzinfo)
+        if fire_at.tzinfo is not None and now.tzinfo is None:
+            return fire_at.replace(tzinfo=None)
+        return fire_at
 
     def _reminder_callback(self, kwargs: dict[str, Any]) -> None:
         self._send_reminder(
@@ -392,15 +532,12 @@ class HabitTracker(hass.Hass):
         data = self.store.data.users[user]
         config = data.habits.get(slot)
         if config is None or not config.configured:
+            self._clear_pending(user, slot)
+            self.store.save()
             return
-        if (
-            data.completions.get(slot, {}).get(
-                self.datetime().date().isoformat(),
-                0,
-            )
-            > 0
-        ):
-            self.reminders.cancel_repeats(user, slot)
+        if self._is_complete_today(user, slot):
+            self._clear_pending(user, slot)
+            self.store.save()
             return
         message = self._fallback_message(config)
         if config.ai_enabled:
@@ -443,14 +580,24 @@ class HabitTracker(hass.Hass):
                 error,
             )
         last_index = final_index or config.repeat_count + 1
-        self.reminders.schedule_next_repeat(
-            user,
-            slot,
-            next_index=reminder_index + 1,
-            final_index=last_index,
-            interval_minutes=config.repeat_interval_minutes,
-            now=self.datetime(),
-        )
+        next_index = reminder_index + 1
+        now = self.datetime()
+        if next_index <= last_index and repeat_fits_before_midnight(
+            now,
+            config.repeat_interval_minutes,
+        ):
+            fire_at = now + timedelta(minutes=config.repeat_interval_minutes)
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=next_index,
+                final_index=last_index,
+            )
+            data.pending_reminders[slot] = pending
+            self._arm_pending(user, slot, pending)
+        else:
+            self._clear_pending(user, slot)
+        self.store.save()
+        self._publish_next_reminder(user, slot)
 
     def _ai_message(
         self,
@@ -713,11 +860,16 @@ class HabitTracker(hass.Hass):
             data.mood_history[yesterday_key] = data.mood_today
         data.mood_today = "Not Set"
         data.mood_note = ""
+        for slot in list(data.habits):
+            self._clear_pending(user, slot)
+        for config in data.habits.values():
+            if config.configured:
+                self._seed_next_reminder(user, config, force=True)
         self.store.save()
         self._publish_mood_state(user)
         for slot in data.habits:
-            self.reminders.cancel_repeats(user, slot)
             self._publish_habit_state(user, slot)
+            self._publish_next_reminder(user, slot)
 
     def _normalize_user_slots(
         self,

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -106,8 +106,13 @@ class HabitTracker(hass.Hass):
         )
         for user in self.users:
             self.run_daily(self._midnight_rollover, time(), user=user)
-        self._restore_reminders()
+        # Defer arming so initialize can finish before run_in(0) callbacks save.
+        self.run_in(self._restore_reminders_callback, 1)
         self.log("Habit tracker initialized for %s", ", ".join(self.users))
+
+    def _restore_reminders_callback(self, _kwargs: dict[str, Any]) -> None:
+        self._restore_reminders()
+        self.store.save()
 
     def terminate(self) -> None:
         """Persist, mark unavailable, and disconnect cleanly."""
@@ -820,13 +825,17 @@ class HabitTracker(hass.Hass):
     ) -> str | None:
         try:
             context = self._ai_context(user, config, reminder_index)
+            # Pass entity_id inside service_data — AppDaemon's top-level entity_id
+            # kwarg is moved into target and HA rejects that shape for ai_task.
             response = self.call_service(
                 "ai_task/generate_data",
-                entity_id=self.args["ai_task_entity"],
-                task_name=(
-                    f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"
-                ),
-                instructions=f"{AI_INSTRUCTIONS}\n\nContext:\n{context}",
+                service_data={
+                    "entity_id": self.args["ai_task_entity"],
+                    "task_name": (
+                        f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"
+                    ),
+                    "instructions": f"{AI_INSTRUCTIONS}\n\nContext:\n{context}",
+                },
                 return_response=True,
             )
         except Exception as error:
@@ -836,6 +845,11 @@ class HabitTracker(hass.Hass):
             generated = response.get("data")
             if isinstance(generated, str) and generated.strip():
                 return generated.strip()
+            nested = response.get("response")
+            if isinstance(nested, dict):
+                generated = nested.get("data")
+                if isinstance(generated, str) and generated.strip():
+                    return generated.strip()
         return None
 
     def _ai_context(

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -11,8 +11,11 @@ from typing import Any, Final, cast
 import appdaemon.plugins.hass.hassapi as hass
 
 from .models import (
+    MAX_DURATION_MINUTES,
     MAX_NAME_LENGTH,
+    MAX_TEMPLATE_LENGTH,
     MOOD_OPTIONS,
+    CompletionMode,
     HabitConfig,
     HabitType,
     PendingReminder,
@@ -231,6 +234,10 @@ class HabitTracker(hass.Hass):
         old_name = config.name
         old_type = config.habit_type
         old_reminder_time = config.reminder_time
+        # Fields are mutated in place, but cross-field rules are only checked
+        # afterwards. Keep a snapshot so a rejected command cannot leave the
+        # in-memory config in a state a later save would persist.
+        snapshot = config.to_dict()
         if key == "name":
             new_name = payload.strip()
             if len(new_name) > MAX_NAME_LENGTH:
@@ -260,6 +267,19 @@ class HabitTracker(hass.Hass):
             if len(icon) > MAX_NAME_LENGTH:
                 raise ValueError("habit icon is too long")
             setattr(config, key, icon)
+        elif key == "completion_mode":
+            config.completion_mode = CompletionMode(payload.strip())
+        elif key == "completion_template":
+            template = payload.strip()
+            if len(template) > MAX_TEMPLATE_LENGTH:
+                raise ValueError("completion template is too long")
+            config.completion_template = template
+        elif key == "completion_duration":
+            config.completion_duration_minutes = _bounded_int(
+                payload,
+                1,
+                MAX_DURATION_MINUTES,
+            )
         elif key == "state":
             self._set_completion(user, slot, 1 if _mqtt_bool(payload) else 0)
             return
@@ -268,7 +288,12 @@ class HabitTracker(hass.Hass):
             return
         else:
             raise KeyError(key)
-        config.__post_init__()
+        try:
+            config.__post_init__()
+        except ValueError:
+            for field_name, previous in snapshot.items():
+                setattr(config, field_name, previous)
+            raise
         if config.name != old_name or config.habit_type is not old_type:
             self._clear_pending(user, slot)
         if (

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -19,6 +19,7 @@ from .models import (
     HabitConfig,
     HabitType,
     PendingReminder,
+    TemplateProgress,
     UnsupportedSchemaVersionError,
     UserData,
     calculate_mood_streak,
@@ -28,6 +29,7 @@ from .models import (
 from .mqtt import HabitMqtt, MqttSettings
 from .reminders import ReminderManager, repeat_fits_before_midnight
 from .store import HabitStore
+from .templates import TemplateWatcher, coerce_truthy, extract_candidate_entities
 
 INVALID_STATES: Final[frozenset[object]] = frozenset(
     {None, "", "unknown", "unavailable"},
@@ -76,6 +78,10 @@ REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
 SLOT_TOPIC_PARTS: Final[int] = 4
 ACTION_PARTS: Final[int] = 3
 MAX_NETWORK_PORT: Final[int] = 65535
+# Ticks on the minute, so a duration-based template reconciles once a minute
+# even if one of its dependencies changes without emitting an event.
+TIME_TICK_ENTITY: Final[str] = "sensor.time"
+MAX_DEBOUNCE_SECONDS: Final[float] = 60
 
 
 class HabitTracker(hass.Hass):
@@ -93,6 +99,12 @@ class HabitTracker(hass.Hass):
             return
         self.mqtt = None
         self.reminders_enabled = bool(self.args.get("reminders_enabled", False))
+        self.template_evaluation_enabled = bool(
+            self.args.get("template_evaluation_enabled", False),
+        )
+        self.template_eval_debounce_seconds = float(
+            self.args.get("template_eval_debounce_seconds", 2),
+        )
         try:
             self.store = HabitStore(
                 Path(
@@ -119,6 +131,12 @@ class HabitTracker(hass.Hass):
         self.store.save()
 
         self.reminders = ReminderManager(self, self._reminder_callback)
+        self.templates = TemplateWatcher(
+            self,
+            self._template_dependency_changed,
+            self._template_evaluation_callback,
+        )
+        self._watched_entities: dict[tuple[str, int], tuple[str, ...]] = {}
         self._configure_mqtt()
         self.listen_event(
             self._handle_notification_action,
@@ -132,12 +150,23 @@ class HabitTracker(hass.Hass):
 
     def _restore_reminders_callback(self, _kwargs: dict[str, Any]) -> None:
         self._restore_reminders()
+        self._restore_templates()
         self.store.save()
+
+    def _restore_templates(self) -> None:
+        """Re-subscribe every event-driven slot and evaluate it once."""
+        for user, data in self.store.data.users.items():
+            for slot, config in data.habits.items():
+                self._rebuild_template_listeners(user, slot)
+                if config.configured and config.completion_mode.is_event_driven:
+                    self._schedule_evaluation(user, slot)
 
     def terminate(self) -> None:
         """Persist, mark unavailable, and disconnect cleanly."""
         with suppress(AttributeError):
             self.reminders.cancel_all()
+        with suppress(AttributeError):
+            self.templates.cancel_all()
         with suppress(AttributeError, OSError):
             self.store.save()
         if self.mqtt is not None:
@@ -305,6 +334,14 @@ class HabitTracker(hass.Hass):
             self._seed_next_reminder(user, config, force=True)
         elif config.configured and slot not in data.pending_reminders:
             self._seed_next_reminder(user, config)
+        if key in {
+            "completion_duration",
+            "completion_mode",
+            "completion_template",
+            "name",
+        }:
+            self._rebuild_template_listeners(user, slot)
+            self._schedule_evaluation(user, slot)
         added_spare, retired = self._normalize_user_slots(user)
         self.store.save()
         if self.mqtt is not None:
@@ -399,6 +436,14 @@ class HabitTracker(hass.Hass):
             self._clear_pending(user, slot)
         elif config.configured:
             self._seed_next_reminder(user, config, force=True)
+        if config.completion_mode.is_event_driven:
+            progress = self._template_progress(user, slot, day)
+            progress.truthy_since = None
+            progress.accumulated_seconds = 0
+            if not count:
+                # A manual un-tick must not be instantly undone by a template
+                # that is still truthy, so stop evaluating this slot for today.
+                progress.suppressed_day = day
         self.store.append_completion_log(user, slot, day, count)
         self.store.save()
         self._publish_habit_state(user, slot)
@@ -449,7 +494,11 @@ class HabitTracker(hass.Hass):
         )
         self.mqtt.publish(
             f"{prefix}/name/attributes",
-            self._slot_attributes(config),
+            {
+                **self._slot_attributes(config),
+                "completion_mode": config.completion_mode,
+                "watched_entities": list(self._watched_entities.get((user, slot), ())),
+            },
         )
 
     def _publish_mood_state(self, user: str) -> None:
@@ -724,6 +773,128 @@ class HabitTracker(hass.Hass):
             f"{self.mqtt.topic(f'{user}/mood')}/mood_next_reminder/state",
             payload,
         )
+
+    def _rebuild_template_listeners(self, user: str, slot: int) -> None:
+        """Re-subscribe a slot to the entities its template actually references."""
+        config = self.store.data.users[user].habits.get(slot)
+        if (
+            config is None
+            or not config.configured
+            or not config.completion_mode.is_event_driven
+        ):
+            self.templates.remove(user, slot)
+            self._watched_entities.pop((user, slot), None)
+            return
+        candidates = extract_candidate_entities(config.completion_template)
+        # The pattern cannot distinguish an entity from an attribute access, so
+        # keep only candidates Home Assistant actually knows about.
+        entities = [name for name in candidates if self.get_state(name) is not None]
+        if not entities:
+            self.error(
+                "Habit template for %s slot %s references no known entities, so it "
+                "will never re-evaluate: %r",
+                user,
+                slot,
+                config.completion_template,
+            )
+        if config.completion_mode.is_duration_based:
+            entities.append(TIME_TICK_ENTITY)
+        self._watched_entities[(user, slot)] = self.templates.watch(
+            user,
+            slot,
+            entities,
+        )
+
+    def _template_dependency_changed(
+        self,
+        entity: str,
+        attribute: str,
+        old: Any,
+        new: Any,
+        **kwargs: Any,
+    ) -> None:
+        del entity, attribute, old, new
+        self._schedule_evaluation(str(kwargs["user"]), int(kwargs["slot"]))
+
+    def _schedule_evaluation(self, user: str, slot: int) -> None:
+        self.templates.schedule(user, slot, self.template_eval_debounce_seconds)
+
+    def _template_evaluation_callback(self, kwargs: dict[str, Any]) -> None:
+        user = str(kwargs["user"])
+        slot = int(kwargs["slot"])
+        self.templates.release(user, slot)
+        self._evaluate_template(user, slot)
+
+    def _template_progress(
+        self,
+        user: str,
+        slot: int,
+        today: str,
+    ) -> TemplateProgress:
+        """Return today's progress record, resetting a stale one."""
+        data = self.store.data.users[user]
+        progress = data.template_progress.get(slot)
+        if progress is None or progress.day != today:
+            progress = TemplateProgress(day=today)
+            data.template_progress[slot] = progress
+        return progress
+
+    def _render_truthy(self, user: str, slot: int, template: str) -> bool:
+        """Render a template, treating any failure as falsy."""
+        try:
+            rendered = self.render_template(template)
+        except Exception as error:
+            self.error("Habit template failed for %s slot %s: %s", user, slot, error)
+            return False
+        truthy = coerce_truthy(rendered)
+        if truthy is None:
+            self.error(
+                "Habit template for %s slot %s returned an unusable value: %r",
+                user,
+                slot,
+                rendered,
+            )
+            return False
+        return truthy
+
+    def _evaluate_template(self, user: str, slot: int) -> None:
+        """Evaluate one slot's completion template and act on the result."""
+        if not self.template_evaluation_enabled:
+            return
+        data = self.store.data.users[user]
+        config = data.habits.get(slot)
+        if config is None or not config.configured:
+            return
+        if not config.completion_mode.is_event_driven:
+            if data.template_progress.pop(slot, None) is not None:
+                self.store.save()
+            return
+        if not config.completion_template.strip():
+            return
+        today = self.datetime().date().isoformat()
+        progress = self._template_progress(user, slot, today)
+        if progress.suppressed_day == today:
+            return
+        if self._is_complete_today(user, slot):
+            progress.truthy_since = None
+            progress.accumulated_seconds = 0
+            self.store.save()
+            return
+        was_truthy = progress.is_truthy
+        now_truthy = self._render_truthy(user, slot, config.completion_template)
+        progress.truthy_since = (
+            self._utc_isoformat(self._aware_now()) if now_truthy else None
+        )
+        if (
+            config.completion_mode is CompletionMode.INSTANT
+            and now_truthy
+            and not was_truthy
+        ):
+            self.log("Habit template completed %s slot %s", user, slot)
+            # _set_completion persists and republishes.
+            self._set_completion(user, slot, 1)
+            return
+        self.store.save()
 
     def _is_complete_today(self, user: str, slot: int) -> bool:
         return (
@@ -1215,6 +1386,11 @@ class HabitTracker(hass.Hass):
             if config.configured:
                 self._seed_next_reminder(user, config, force=True)
         self._seed_mood_reminder(user, force=True)
+        # Progress records are keyed by day, so a stale one is replaced on the
+        # next evaluation rather than cleared here.
+        for slot, config in data.habits.items():
+            if config.configured and config.completion_mode.is_event_driven:
+                self._schedule_evaluation(user, slot)
         self.store.save()
         self._publish_mood_state(user)
         for slot in data.habits:
@@ -1231,6 +1407,9 @@ class HabitTracker(hass.Hass):
         for slot in retired:
             with suppress(AttributeError):
                 self.reminders.remove(user, slot)
+            with suppress(AttributeError):
+                self.templates.remove(user, slot)
+            self._watched_entities.pop((user, slot), None)
         return added_spare, retired
 
     def _validate_config(self) -> bool:  # noqa: C901, PLR0912
@@ -1255,6 +1434,12 @@ class HabitTracker(hass.Hass):
                 errors.append("mqtt_qos")
         except (TypeError, ValueError):
             errors.append("mqtt_qos")
+        try:
+            debounce = float(self.args.get("template_eval_debounce_seconds", 2))
+            if not 0 <= debounce <= MAX_DEBOUNCE_SECONDS:
+                errors.append("template_eval_debounce_seconds")
+        except (TypeError, ValueError):
+            errors.append("template_eval_debounce_seconds")
         for key in ("mqtt_discovery_prefix", "mqtt_base_topic"):
             value = self.args.get(key)
             if value is not None and (not isinstance(value, str) or not value.strip("/")):

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -1,0 +1,973 @@
+"""Disk-backed, MQTT-discovered habit and mood tracker."""
+
+from __future__ import annotations
+
+import json
+from contextlib import suppress
+from datetime import datetime, time, timedelta
+from pathlib import Path
+from typing import Any, Final, cast
+
+import appdaemon.plugins.hass.hassapi as hass
+
+from .models import (
+    MAX_NAME_LENGTH,
+    MOOD_OPTIONS,
+    HabitConfig,
+    HabitType,
+    calculate_mood_streak,
+    calculate_streak,
+    normalize_spare_slot,
+)
+from .mqtt import HabitMqtt, MqttSettings
+from .reminders import ReminderManager
+from .store import HabitStore
+
+INVALID_STATES: Final[frozenset[object]] = frozenset(
+    {None, "", "unknown", "unavailable"},
+)
+AI_INSTRUCTIONS: Final[str] = """Write one short habit reminder notification message.
+
+Tone: neutral, positive, and encouraging. Do not be sarcastic, preachy, or overly
+casual. Do not invent facts.
+
+Requirements:
+- Return only the notification message text
+- One or two short sentences maximum
+- Mention the habit name naturally
+- You may mention streak, mood, completion rate, or that this is a repeat reminder
+  when that context is useful
+- Use location only when it materially affects whether the habit is feasible right
+  now. For example, do not encourage doing skincare immediately when the user is at
+  work; still give a useful reminder, such as doing it later or keeping a streak in mind
+- If the user is in a meeting or has only a short free window, suggest a realistic
+  later time instead of interrupting them
+- Use weather and daylight only when they materially affect an outdoor habit
+- Do not name specific places, addresses, or coordinates
+- Do not include markdown, emojis, quotes, or a title"""
+
+REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
+    "notify_script",
+    "dashboard_url",
+    "person_entity",
+    "at_work_entity",
+    "workday_entity",
+    "activity_entity",
+    "steps_entity",
+    "exercise_entity",
+    "weather_entity",
+    "sun_entity",
+)
+TEST_TOPIC_PARTS: Final[int] = 3
+SLOT_TOPIC_PARTS: Final[int] = 4
+ACTION_PARTS: Final[int] = 3
+MAX_NETWORK_PORT: Final[int] = 65535
+
+
+class HabitTracker(hass.Hass):
+    """Manage dynamic habit entities, persistence, reminders, and mood."""
+
+    mqtt: HabitMqtt | None
+
+    def initialize(self) -> None:
+        """Load disk state, bootstrap legacy helpers, and start integrations."""
+        self.users = tuple(str(user).lower() for user in self.args.get("users", ()))
+        if not self.users:
+            self.error("At least one user is required")
+            return
+        if not self._validate_config():
+            return
+        self.mqtt = None
+        self.reminders_enabled = bool(self.args.get("reminders_enabled", False))
+        self.store = HabitStore(
+            Path(
+                str(
+                    self.args.get(
+                        "store_directory",
+                        "/homeassistant/.appdaemon/habits",
+                    ),
+                ),
+            ),
+            self.users,
+        )
+        if not self.store.existed and not self.store.data.bootstrap_complete:
+            self._bootstrap_legacy_helpers()
+        self._startup_retired: dict[str, tuple[int, ...]] = {}
+        for user in self.users:
+            _, retired = self._normalize_user_slots(user)
+            self._startup_retired[user] = retired
+        self.store.save()
+
+        self.reminders = ReminderManager(self, self._reminder_callback)
+        self._configure_mqtt()
+        self.listen_event(
+            self._handle_notification_action,
+            "mobile_app_notification_action",
+        )
+        for user in self.users:
+            self.run_daily(self._midnight_rollover, time(), user=user)
+        self._schedule_all()
+        self.log("Habit tracker initialized for %s", ", ".join(self.users))
+
+    def terminate(self) -> None:
+        """Persist, mark unavailable, and disconnect cleanly."""
+        with suppress(AttributeError):
+            self.reminders.cancel_all()
+        with suppress(AttributeError, OSError):
+            self.store.save()
+        if self.mqtt is not None:
+            self.mqtt.disconnect()
+
+    def _configure_mqtt(self) -> None:
+        host = self.args.get("mqtt_host")
+        if not isinstance(host, str) or not host:
+            self.error("mqtt_host is required")
+            return
+        settings = MqttSettings(
+            host=host,
+            port=int(self.args.get("mqtt_port", 1883)),
+            username=_optional_string(self.args.get("mqtt_username")),
+            password=_optional_string(self.args.get("mqtt_password")),
+            discovery_prefix=str(
+                self.args.get("mqtt_discovery_prefix", "homeassistant"),
+            ).strip("/"),
+            base_topic=str(
+                self.args.get("mqtt_base_topic", "appdaemon/habits"),
+            ).strip("/"),
+            qos=int(self.args.get("mqtt_qos", 0)),
+        )
+        self.mqtt = HabitMqtt(
+            settings,
+            on_command=self._handle_mqtt_command,
+            dispatch=self._dispatch_from_mqtt,
+            on_connect=self._publish_all,
+            log=self.log,
+        )
+        try:
+            self.mqtt.connect()
+        except Exception as error:
+            self.error("Unable to connect habit MQTT client: %s", error)
+            with suppress(Exception):
+                self.mqtt.disconnect()
+            self.mqtt = None
+
+    def _dispatch_from_mqtt(
+        self,
+        callback: Any,
+        topic: str,
+        payload: str,
+    ) -> None:
+        self.run_in(
+            self._run_dispatched,
+            0,
+            dispatched_callback=callback,
+            topic=topic,
+            payload=payload,
+        )
+
+    def _run_dispatched(self, kwargs: dict[str, Any]) -> None:
+        callback = kwargs["dispatched_callback"]
+        callback(str(kwargs["topic"]), str(kwargs["payload"]))
+
+    def _publish_all(self) -> None:
+        if self.mqtt is None:
+            return
+        self.mqtt.publish_mood_discovery(self.users)
+        for user in self.users:
+            self.mqtt.publish_user_discovery(user)
+            for retired_slot in self._startup_retired[user]:
+                self.mqtt.retire_slot(user, retired_slot)
+            for config in self.store.data.users[user].habits.values():
+                self.mqtt.publish_slot(user, config)
+                self._publish_habit_state(user, config.slot)
+            self._publish_mood_state(user)
+
+    def _handle_mqtt_command(self, topic: str, payload: str) -> None:
+        if self.mqtt is None:
+            return
+        prefix = f"{self.mqtt.settings.base_topic}/"
+        if not topic.startswith(prefix) or not topic.endswith("/set"):
+            return
+        parts = topic[len(prefix) :].split("/")
+        try:
+            if len(parts) == TEST_TOPIC_PARTS and parts[1] == "test":
+                self._send_test_reminder(parts[0])
+            elif len(parts) == SLOT_TOPIC_PARTS and parts[1] == "mood":
+                self._update_mood(parts[0], parts[2], payload)
+            elif len(parts) == SLOT_TOPIC_PARTS:
+                self._update_habit(parts[0], int(parts[1]), parts[2], payload)
+        except (KeyError, TypeError, ValueError) as error:
+            self.error("Rejected MQTT command %s=%r: %s", topic, payload, error)
+
+    def _update_habit(  # noqa: C901, PLR0912
+        self,
+        user: str,
+        slot: int,
+        key: str,
+        payload: str,
+    ) -> None:
+        data = self.store.data.users[user]
+        config = data.habits[slot]
+        old_name = config.name
+        old_type = config.habit_type
+        if key == "name":
+            new_name = payload.strip()
+            if len(new_name) > MAX_NAME_LENGTH:
+                raise ValueError("habit name is too long")
+            config.name = new_name
+            if old_name.strip() and not new_name:
+                data.completions.pop(slot, None)
+        elif key == "type":
+            config.habit_type = HabitType(payload)
+        elif key == "reminder_time":
+            time.fromisoformat(payload)
+            config.reminder_time = payload
+        elif key == "repeat_count":
+            config.repeat_count = _bounded_int(payload, 0, 100)
+        elif key == "repeat_interval":
+            config.repeat_interval_minutes = _bounded_int(payload, 1, 1440)
+        elif key == "streak_min_days":
+            config.streak_min_days_per_week = _bounded_int(payload, 1, 7)
+        elif key == "ai":
+            config.ai_enabled = _mqtt_bool(payload)
+        elif key in {"icon_on", "icon_active", "icon_off", "icon_zero"}:
+            icon = payload.strip()
+            if len(icon) > MAX_NAME_LENGTH:
+                raise ValueError("habit icon is too long")
+            setattr(config, key, icon)
+        elif key == "state":
+            self._set_completion(user, slot, 1 if _mqtt_bool(payload) else 0)
+            return
+        elif key == "count":
+            self._set_completion(user, slot, _bounded_int(payload, 0, 100000))
+            return
+        else:
+            raise KeyError(key)
+        config.__post_init__()
+        if config.name != old_name or config.habit_type is not old_type:
+            self.reminders.cancel_repeats(user, slot)
+        self._reschedule(user, config)
+        added_spare, retired = self._normalize_user_slots(user)
+        self.store.save()
+        if self.mqtt is not None:
+            if slot in data.habits:
+                self.mqtt.publish_slot(user, config)
+                self._publish_habit_state(user, slot)
+            if added_spare is not None and added_spare != slot:
+                spare = data.habits[added_spare]
+                self.mqtt.publish_slot(user, spare)
+                self._publish_habit_state(user, added_spare)
+            for retired_slot in retired:
+                self.mqtt.retire_slot(user, retired_slot)
+
+    def _update_mood(self, user: str, key: str, payload: str) -> None:
+        data = self.store.data.users[user]
+        today = self.datetime().date().isoformat()
+        if key == "mood_today":
+            if payload not in MOOD_OPTIONS:
+                raise ValueError("invalid mood option")
+            data.mood_today = payload
+            if payload != "Not Set":
+                data.mood_history[today] = payload
+            else:
+                data.mood_history.pop(today, None)
+        elif key == "mood_note":
+            data.mood_note = payload[:255]
+        else:
+            raise KeyError(key)
+        self.store.save()
+        self._publish_mood_state(user)
+
+    def _set_completion(self, user: str, slot: int, count: int) -> None:
+        day = self.datetime().date().isoformat()
+        values = self.store.data.users[user].completions.setdefault(slot, {})
+        if count:
+            values[day] = count
+        else:
+            values.pop(day, None)
+        self.reminders.cancel_repeats(user, slot)
+        self.store.append_completion_log(user, slot, day, count)
+        self.store.save()
+        self._publish_habit_state(user, slot)
+
+    def _publish_habit_state(self, user: str, slot: int) -> None:
+        if self.mqtt is None:
+            return
+        data = self.store.data.users[user]
+        config = data.habits[slot]
+        today = self.datetime().date()
+        today_count = data.completions.get(slot, {}).get(today.isoformat(), 0)
+        prefix = self.mqtt.topic(f"{user}/{slot}")
+        self.mqtt.publish(f"{prefix}/state/state", "ON" if today_count else "OFF")
+        self.mqtt.publish(f"{prefix}/count/state", str(today_count))
+        stats = calculate_streak(
+            data.completions.get(slot, {}),
+            today=today,
+            min_days_per_week=config.streak_min_days_per_week,
+        )
+        self.mqtt.publish(
+            f"{prefix}/streak/state",
+            str(stats.streak),
+        )
+        self.mqtt.publish(
+            f"{prefix}/streak/attributes",
+            {
+                **self._slot_attributes(config),
+                "days_since_completion": stats.days_since_completion,
+                "completion_rate_28_days": stats.completion_rate_28_days,
+            },
+        )
+        state_key = "state" if config.habit_type is HabitType.BINARY else "count"
+        self.mqtt.publish(
+            f"{prefix}/{state_key}/attributes",
+            {
+                **self._slot_attributes(config),
+                "icon": (
+                    config.icon_on
+                    if config.habit_type is HabitType.BINARY and today_count
+                    else config.icon_off
+                    if config.habit_type is HabitType.BINARY
+                    else config.icon_active
+                    if today_count
+                    else config.icon_zero
+                ),
+            },
+        )
+        self.mqtt.publish(
+            f"{prefix}/name/attributes",
+            self._slot_attributes(config),
+        )
+
+    def _publish_mood_state(self, user: str) -> None:
+        if self.mqtt is None:
+            return
+        data = self.store.data.users[user]
+        prefix = self.mqtt.topic(f"{user}/mood")
+        self.mqtt.publish(f"{prefix}/mood_today/state", data.mood_today)
+        self.mqtt.publish(f"{prefix}/mood_note/state", data.mood_note)
+        self.mqtt.publish(
+            f"{prefix}/mood_streak/state",
+            str(
+                calculate_mood_streak(
+                    data.mood_history,
+                    today=self.datetime().date(),
+                ),
+            ),
+        )
+
+    def _schedule_all(self) -> None:
+        if not self.reminders_enabled:
+            return
+        for user, data in self.store.data.users.items():
+            for config in data.habits.values():
+                self._reschedule(user, config)
+
+    def _reschedule(self, user: str, config: HabitConfig) -> None:
+        if self.reminders_enabled and config.configured:
+            self.reminders.schedule_daily(user, config.slot, config.reminder_time)
+        else:
+            self.reminders.remove(user, config.slot)
+
+    def _reminder_callback(self, kwargs: dict[str, Any]) -> None:
+        self._send_reminder(
+            str(kwargs["user"]),
+            int(kwargs["slot"]),
+            int(kwargs["reminder_index"]),
+            final_index=int(
+                kwargs.get(
+                    "final_index",
+                    self.store.data.users[str(kwargs["user"])]
+                    .habits[int(kwargs["slot"])]
+                    .repeat_count
+                    + 1,
+                ),
+            ),
+        )
+
+    def _send_reminder(
+        self,
+        user: str,
+        slot: int,
+        reminder_index: int,
+        *,
+        final_index: int | None = None,
+        force: bool = False,
+    ) -> None:
+        if not force and not self.reminders_enabled:
+            return
+        data = self.store.data.users[user]
+        config = data.habits.get(slot)
+        if config is None or not config.configured:
+            return
+        if (
+            data.completions.get(slot, {}).get(
+                self.datetime().date().isoformat(),
+                0,
+            )
+            > 0
+        ):
+            self.reminders.cancel_repeats(user, slot)
+            return
+        message = self._fallback_message(config)
+        if config.ai_enabled:
+            message = self._ai_message(user, config, reminder_index) or message
+        action = (
+            f"MARK_HABIT_AS_COMPLETE__{user.upper()}__{slot}"
+            if config.habit_type is HabitType.BINARY
+            else f"INCREMENT_HABIT__{user.upper()}__{slot}"
+        )
+        user_config = self._user_config(user)
+        try:
+            self.call_service(
+                "script/turn_on",
+                entity_id=user_config["notify_script"],
+                variables={
+                    "title": "Habit Reminder",
+                    "message": message,
+                    "notification_id": f"{user}_habit_{slot}_reminder",
+                    "mobile_notification_icon": "mdi:checkbox-marked-circle-outline",
+                    "url": user_config["dashboard_url"],
+                    "actions": json.dumps(
+                        [
+                            {
+                                "action": action,
+                                "title": (
+                                    "Mark as Complete"
+                                    if config.habit_type is HabitType.BINARY
+                                    else "Increment"
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            )
+        except Exception as error:
+            self.error(
+                "Habit reminder notification failed for %s slot %s: %s",
+                user,
+                slot,
+                error,
+            )
+        if not force:
+            last_index = final_index or config.repeat_count + 1
+            self.reminders.schedule_next_repeat(
+                user,
+                slot,
+                next_index=reminder_index + 1,
+                final_index=last_index,
+                interval_minutes=config.repeat_interval_minutes,
+                now=self.datetime(),
+            )
+
+    def _send_test_reminder(self, user: str) -> None:
+        """Test the lowest numbered configured incomplete habit."""
+        today = self.datetime().date().isoformat()
+        data = self.store.data.users[user]
+        candidates = sorted(
+            config.slot
+            for config in data.habits.values()
+            if config.configured
+            and data.completions.get(config.slot, {}).get(today, 0) == 0
+        )
+        if not candidates:
+            self.log(
+                "No configured incomplete habit available for %s test reminder",
+                user,
+                level="WARNING",
+            )
+            return
+        self._send_reminder(user, candidates[0], 1, force=True)
+
+    def _ai_message(
+        self,
+        user: str,
+        config: HabitConfig,
+        reminder_index: int,
+    ) -> str | None:
+        try:
+            context = self._ai_context(user, config, reminder_index)
+            response = self.call_service(
+                "ai_task/generate_data",
+                entity_id=self.args["ai_task_entity"],
+                task_name=(
+                    f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"
+                ),
+                instructions=f"{AI_INSTRUCTIONS}\n\nContext:\n{context}",
+                return_response=True,
+            )
+        except Exception as error:
+            self.error("AI habit reminder failed: %s", error)
+            return None
+        if isinstance(response, dict):
+            generated = response.get("data")
+            if isinstance(generated, str) and generated.strip():
+                return generated.strip()
+        return None
+
+    def _ai_context(
+        self,
+        user: str,
+        config: HabitConfig,
+        reminder_index: int,
+    ) -> str:
+        data = self.store.data.users[user]
+        user_config = self._user_config(user)
+        now = self.datetime()
+        stats = calculate_streak(
+            data.completions.get(config.slot, {}),
+            today=now.date(),
+            min_days_per_week=config.streak_min_days_per_week,
+        )
+        repeat_total = config.repeat_count + 1
+        attempt = (
+            "first reminder today"
+            if reminder_index == 1
+            else f"final reminder today (attempt {reminder_index})"
+            if reminder_index >= repeat_total
+            else f"repeat reminder {reminder_index} of {repeat_total}"
+        )
+        pairs: list[tuple[str, object]] = [
+            ("User", user.title()),
+            ("Habit name", config.name),
+            ("Habit type", config.habit_type),
+            ("Current streak days", stats.streak),
+            ("Days since completion", stats.days_since_completion),
+            ("28-day completion rate", stats.completion_rate_28_days),
+            ("Mood today", data.mood_today),
+            ("Mood note", data.mood_note),
+            ("Location category", self._location_category(user_config)),
+            ("Calendar availability", self._calendar_availability(user, now)),
+            (
+                "Workday",
+                "yes"
+                if self.get_state(str(user_config["workday_entity"])) == "on"
+                else "no",
+            ),
+            (
+                "Current physical activity",
+                self._state_value(str(user_config["activity_entity"])),
+            ),
+            (
+                "Steps so far today",
+                self._numeric_state(str(user_config["steps_entity"]), integer=True),
+            ),
+            (
+                "Exercise bike active minutes",
+                self._bike_minutes(str(user_config["exercise_entity"])),
+            ),
+            ("Weather", self._weather_summary(str(user_config["weather_entity"]))),
+            (
+                "Daylight remaining minutes",
+                self._daylight_minutes(str(user_config["sun_entity"]), now),
+            ),
+            ("Local time", now.strftime("%H:%M")),
+            ("Reminder attempt", attempt),
+        ]
+        return "\n".join(
+            f"- {label}: {value}"
+            for label, value in pairs
+            if value not in INVALID_STATES and value not in {"Not Set", -1}
+        )
+
+    def _location_category(self, user_config: dict[str, Any]) -> str:
+        person_entity = str(user_config["person_entity"])
+        person_state = self.get_state(person_entity)
+        all_state = self.get_state(person_entity, attribute="all")
+        in_zones: list[str] = []
+        if isinstance(all_state, dict):
+            attributes = all_state.get("attributes")
+            if isinstance(attributes, dict) and isinstance(
+                attributes.get("in_zones"),
+                list,
+            ):
+                in_zones = [str(zone) for zone in attributes["in_zones"]]
+        labels = self._context_labels()
+        for category, key in (
+            ("home", "home"),
+            ("work", "work"),
+            ("family location", "family"),
+        ):
+            if set(in_zones) & set(self._label_entities(str(labels[key]))):
+                return category
+        if self.get_state(str(user_config["at_work_entity"])) == "on":
+            return "work"
+        if person_state == "home":
+            return "home"
+        if person_state == "not_home":
+            return "away from known zones"
+        return (
+            "known but unclassified location"
+            if person_state not in INVALID_STATES
+            else "unknown"
+        )
+
+    def _calendar_availability(  # noqa: C901, PLR0911, PLR0912
+        self,
+        user: str,
+        now: datetime,
+    ) -> str:
+        calendar_labels = self._context_labels()["calendar"]
+        if not isinstance(calendar_labels, dict):
+            return ""
+        label = calendar_labels.get(user)
+        entities = self._label_entities(label) if isinstance(label, str) else []
+        if not entities:
+            return ""
+        try:
+            response = self.call_service(
+                "calendar/get_events",
+                entity_id=entities,
+                duration={"hours": 8},
+                return_response=True,
+            )
+        except Exception as error:
+            self.error("Calendar context failed for %s: %s", user, error)
+            return ""
+        if not isinstance(response, dict):
+            return ""
+        busy_until: datetime | None = None
+        next_start: datetime | None = None
+        for calendar in response.values():
+            if not isinstance(calendar, dict) or not isinstance(
+                calendar.get("events"),
+                list,
+            ):
+                continue
+            for event in calendar["events"]:
+                if not isinstance(event, dict):
+                    continue
+                start = _event_datetime(event.get("start"), now)
+                end = _event_datetime(event.get("end"), now)
+                if start is None or end is None:
+                    continue
+                if start <= now < end and (busy_until is None or end > busy_until):
+                    busy_until = end
+                elif start > now and (next_start is None or start < next_start):
+                    next_start = start
+        if busy_until is not None:
+            minutes = round((busy_until - now).total_seconds() / 60)
+            return f"in a meeting for the next {minutes} minutes"
+        if next_start is not None:
+            minutes = round((next_start - now).total_seconds() / 60)
+            return f"free for the next {minutes} minutes"
+        return "nothing scheduled in the next 8 hours"
+
+    def _label_entities(self, label: str) -> list[str]:
+        entities = cast("Any", self).label_entities(label)
+        return [str(entity) for entity in entities] if isinstance(entities, list) else []
+
+    def _state_value(self, entity_id: str) -> str | int | float:
+        value = self.get_state(entity_id)
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, str | int | float)
+            or value in INVALID_STATES
+        ):
+            return ""
+        return value
+
+    def _numeric_state(
+        self,
+        entity_id: str,
+        *,
+        integer: bool = False,
+    ) -> str | int | float:
+        value = self._state_value(entity_id)
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return ""
+        return int(numeric) if integer else numeric
+
+    def _bike_minutes(self, entity_id: str) -> str | float:
+        seconds = self._numeric_state(entity_id)
+        return (
+            "" if not isinstance(seconds, int | float) else round(float(seconds) / 60, 1)
+        )
+
+    def _weather_summary(self, entity_id: str) -> str:
+        condition = self._state_value(entity_id)
+        temperature = self.get_state(entity_id, attribute="temperature")
+        if condition == "" or temperature in INVALID_STATES:
+            return ""
+        return f"{condition}, {temperature}°C"
+
+    def _daylight_minutes(self, entity_id: str, now: datetime) -> int:
+        if self.get_state(entity_id) != "above_horizon":
+            return 0
+        parsed = _event_datetime(
+            self.get_state(entity_id, attribute="next_setting"),
+            now,
+        )
+        return 0 if parsed is None else max(0, round((parsed - now).total_seconds() / 60))
+
+    @staticmethod
+    def _fallback_message(config: HabitConfig) -> str:
+        if config.habit_type is HabitType.BINARY:
+            return f"Don't forget to mark {config.name} as complete!"
+        return f"Don't forget to track {config.name}!"
+
+    def _handle_notification_action(
+        self,
+        event_type: str,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        del event_type, kwargs
+        action = data.get("action")
+        if not isinstance(action, str):
+            return
+        parts = action.split("__")
+        if len(parts) != ACTION_PARTS:
+            return
+        verb, user_upper, slot_raw = parts
+        user = user_upper.lower()
+        try:
+            slot = int(slot_raw)
+            config = self.store.data.users[user].habits[slot]
+        except (KeyError, ValueError):
+            return
+        current = (
+            self.store.data.users[user]
+            .completions.get(slot, {})
+            .get(
+                self.datetime().date().isoformat(),
+                0,
+            )
+        )
+        if verb == "MARK_HABIT_AS_COMPLETE" and config.habit_type is HabitType.BINARY:
+            self._set_completion(user, slot, 1)
+        elif verb == "INCREMENT_HABIT" and config.habit_type is HabitType.COUNTABLE:
+            self._set_completion(user, slot, current + 1)
+
+    def _midnight_rollover(self, kwargs: dict[str, Any]) -> None:
+        user = str(kwargs["user"])
+        data = self.store.data.users[user]
+        today = self.datetime().date()
+        yesterday_key = (today - timedelta(days=1)).isoformat()
+        if data.mood_today != "Not Set":
+            data.mood_history[yesterday_key] = data.mood_today
+        data.mood_today = "Not Set"
+        data.mood_note = ""
+        self.store.save()
+        self._publish_mood_state(user)
+        for slot in data.habits:
+            self.reminders.cancel_repeats(user, slot)
+            self._publish_habit_state(user, slot)
+
+    def _normalize_user_slots(
+        self,
+        user: str,
+    ) -> tuple[int | None, tuple[int, ...]]:
+        """Keep the lowest stable spare and retire every other empty slot."""
+        data = self.store.data.users[user]
+        added_spare, retired = normalize_spare_slot(data)
+        for slot in retired:
+            with suppress(AttributeError):
+                self.reminders.remove(user, slot)
+        return added_spare, retired
+
+    def _bootstrap_legacy_helpers(self) -> None:
+        for user in self.users:
+            data = self.store.data.users[user]
+            data.habits.clear()
+            names = self.get_state("input_text") or {}
+            if not isinstance(names, dict):
+                continue
+            prefix = f"{user}_habit_"
+            slots: set[tuple[HabitType, int]] = set()
+            for entity_id in names:
+                object_id = str(entity_id).removeprefix("input_text.")
+                if not object_id.startswith(prefix) or not object_id.endswith("_name"):
+                    continue
+                middle = object_id[len(prefix) : -len("_name")]
+                habit_type_raw, _, slot_raw = middle.rpartition("_")
+                with suppress(ValueError):
+                    slots.add((HabitType(habit_type_raw), int(slot_raw)))
+            for habit_type, old_slot in sorted(
+                slots,
+                key=lambda item: (item[0], item[1]),
+            ):
+                old_prefix = f"{user}_habit_{habit_type}_{old_slot}"
+                name = self._legacy_state(f"input_text.{old_prefix}_name")
+                if not name:
+                    continue
+                new_slot = max(data.habits, default=0) + 1
+                config = HabitConfig(
+                    slot=new_slot,
+                    name=name,
+                    habit_type=habit_type,
+                    reminder_time=self._legacy_state(
+                        f"input_datetime.{old_prefix}_reminder_time",
+                        "09:00:00",
+                    ),
+                    repeat_count=self._legacy_int(
+                        f"input_number.{old_prefix}_repeat_reminder_count",
+                        0,
+                    ),
+                    repeat_interval_minutes=self._legacy_int(
+                        f"input_number.{old_prefix}_repeat_reminder_interval",
+                        60,
+                    ),
+                    streak_min_days_per_week=self._legacy_int(
+                        f"input_number.{old_prefix}_streak_min_days_per_week",
+                        7,
+                    ),
+                    ai_enabled=self._legacy_state(
+                        f"input_boolean.{old_prefix}_ai_reminder",
+                    )
+                    == "on",
+                    icon_on=self._legacy_state(
+                        f"input_text.{old_prefix}_icon_on",
+                        "mdi:check-circle",
+                    ),
+                    icon_active=self._legacy_state(
+                        f"input_text.{old_prefix}_icon_active",
+                        "mdi:counter",
+                    ),
+                    icon_off=self._legacy_state(
+                        f"input_text.{old_prefix}_icon_off",
+                        "mdi:circle-outline",
+                    ),
+                    icon_zero=self._legacy_state(
+                        f"input_text.{old_prefix}_icon_zero",
+                        "mdi:counter",
+                    ),
+                )
+                data.habits[new_slot] = config
+                state_domain = (
+                    "input_boolean" if habit_type is HabitType.BINARY else "input_number"
+                )
+                current = self._legacy_state(f"{state_domain}.{old_prefix}", "0")
+                count = 1 if current == "on" else int(float(current))
+                if count > 0:
+                    data.completions[new_slot] = {
+                        self.datetime().date().isoformat(): count,
+                    }
+            data.mood_today = self._legacy_state(
+                f"input_select.{user}_mood_today",
+                "Not Set",
+            )
+            data.mood_note = self._legacy_state(f"input_text.{user}_mood_note")
+        self.store.data.bootstrap_complete = True
+
+    def _legacy_state(self, entity_id: str, default: str = "") -> str:
+        value = self.get_state(entity_id)
+        return default if value in INVALID_STATES else str(value)
+
+    def _legacy_int(self, entity_id: str, default: int) -> int:
+        value = self._legacy_state(entity_id)
+        try:
+            return int(float(value))
+        except ValueError:
+            return default
+
+    def _validate_config(self) -> bool:  # noqa: C901, PLR0912
+        errors: list[str] = []
+        if len(set(self.users)) != len(self.users):
+            errors.append("users (duplicates)")
+        if (
+            not isinstance(self.args.get("ai_task_entity"), str)
+            or not self.args["ai_task_entity"]
+        ):
+            errors.append("ai_task_entity")
+        if not isinstance(self.args.get("mqtt_host"), str) or not self.args["mqtt_host"]:
+            errors.append("mqtt_host")
+        try:
+            port = int(self.args.get("mqtt_port", 1883))
+            if not 1 <= port <= MAX_NETWORK_PORT:
+                errors.append("mqtt_port")
+        except (TypeError, ValueError):
+            errors.append("mqtt_port")
+        try:
+            if int(self.args.get("mqtt_qos", 0)) not in {0, 1, 2}:
+                errors.append("mqtt_qos")
+        except (TypeError, ValueError):
+            errors.append("mqtt_qos")
+        for key in ("mqtt_discovery_prefix", "mqtt_base_topic"):
+            value = self.args.get(key)
+            if value is not None and (not isinstance(value, str) or not value.strip("/")):
+                errors.append(key)
+        configs = self.args.get("user_config")
+        if not isinstance(configs, dict):
+            errors.append("user_config")
+        else:
+            for user in self.users:
+                config = configs.get(user)
+                if not isinstance(config, dict):
+                    errors.append(f"user_config.{user}")
+                    continue
+                errors.extend(
+                    f"user_config.{user}.{key}"
+                    for key in REQUIRED_USER_KEYS
+                    if not isinstance(config.get(key), str) or not config[key]
+                )
+        labels = self.args.get("context_labels")
+        if not isinstance(labels, dict):
+            errors.append("context_labels")
+        else:
+            errors.extend(
+                f"context_labels.{key}"
+                for key in ("home", "work", "family")
+                if not isinstance(labels.get(key), str) or not labels[key]
+            )
+            calendars = labels.get("calendar")
+            if not isinstance(calendars, dict):
+                errors.append("context_labels.calendar")
+            else:
+                errors.extend(
+                    f"context_labels.calendar.{user}"
+                    for user in self.users
+                    if not isinstance(calendars.get(user), str) or not calendars[user]
+                )
+        if errors:
+            self.error("Invalid habit tracker configuration: %s", ", ".join(errors))
+            return False
+        return True
+
+    def _slot_attributes(self, config: HabitConfig) -> dict[str, object]:
+        return {
+            "configured": config.configured,
+            "habit_name": config.name,
+            "habit_type": config.habit_type,
+            "slot": config.slot,
+        }
+
+    def _context_labels(self) -> dict[str, Any]:
+        return cast("dict[str, Any]", self.args["context_labels"])
+
+    def _user_config(self, user: str) -> dict[str, Any]:
+        configs = self.args.get("user_config", {})
+        if not isinstance(configs, dict) or not isinstance(configs.get(user), dict):
+            raise TypeError(f"missing user_config for {user}")
+        return cast("dict[str, Any]", configs[user])
+
+
+def _mqtt_bool(payload: str) -> bool:
+    normalized = payload.strip().lower()
+    if normalized in {"on", "true", "1"}:
+        return True
+    if normalized in {"off", "false", "0"}:
+        return False
+    raise ValueError("expected an on/off value")
+
+
+def _bounded_int(payload: str, minimum: int, maximum: int) -> int:
+    value = int(float(payload))
+    if not minimum <= value <= maximum:
+        raise ValueError(f"value must be between {minimum} and {maximum}")
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _event_datetime(value: object, now: datetime) -> datetime | None:
+    if not isinstance(value, str) or "T" not in value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=now.tzinfo)

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import suppress
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Final, cast
 
@@ -28,6 +28,7 @@ from .store import HabitStore
 INVALID_STATES: Final[frozenset[object]] = frozenset(
     {None, "", "unknown", "unavailable"},
 )
+NEXT_REMINDER_ECHO_TOLERANCE_SECONDS: Final[float] = 2
 AI_INSTRUCTIONS: Final[str] = """Write one short habit reminder notification message.
 
 Tone: neutral, positive, and encouraging. Do not be sarcastic, preachy, or overly
@@ -482,7 +483,7 @@ class HabitTracker(hass.Hass):
         )
         fire_at = max(fire_at, now)
         pending = PendingReminder(
-            fire_at=fire_at.isoformat(),
+            fire_at=self._utc_isoformat(fire_at),
             next_index=1,
             final_index=config.repeat_count + 1,
         )
@@ -507,7 +508,7 @@ class HabitTracker(hass.Hass):
         )
         fire_at = max(fire_at, now)
         pending = PendingReminder(
-            fire_at=fire_at.isoformat(),
+            fire_at=self._utc_isoformat(fire_at),
             next_index=1,
             final_index=data.mood_repeat_count + 1,
         )
@@ -527,15 +528,23 @@ class HabitTracker(hass.Hass):
             raise ValueError("habit is not configured")
         fire_at = self._parse_fire_at(payload)
         pending = data.pending_reminders.get(slot)
+        if (
+            pending is not None
+            and abs(
+                (fire_at - self._parse_fire_at(pending.fire_at)).total_seconds(),
+            )
+            < NEXT_REMINDER_ECHO_TOLERANCE_SECONDS
+        ):
+            return
         if pending is None:
             pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
+                fire_at=self._utc_isoformat(fire_at),
                 next_index=1,
                 final_index=config.repeat_count + 1,
             )
         else:
             pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
+                fire_at=self._utc_isoformat(fire_at),
                 next_index=pending.next_index,
                 final_index=pending.final_index,
             )
@@ -553,15 +562,23 @@ class HabitTracker(hass.Hass):
             return
         fire_at = self._parse_fire_at(payload)
         pending = data.pending_mood_reminder
+        if (
+            pending is not None
+            and abs(
+                (fire_at - self._parse_fire_at(pending.fire_at)).total_seconds(),
+            )
+            < NEXT_REMINDER_ECHO_TOLERANCE_SECONDS
+        ):
+            return
         if pending is None:
             pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
+                fire_at=self._utc_isoformat(fire_at),
                 next_index=1,
                 final_index=data.mood_repeat_count + 1,
             )
         else:
             pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
+                fire_at=self._utc_isoformat(fire_at),
                 next_index=pending.next_index,
                 final_index=pending.final_index,
             )
@@ -616,7 +633,7 @@ class HabitTracker(hass.Hass):
         payload = (
             "None"
             if pending is None
-            else self._parse_fire_at(pending.fire_at).isoformat()
+            else self._utc_isoformat(self._parse_fire_at(pending.fire_at))
         )
         self.mqtt.publish(
             f"{self.mqtt.topic(f'{user}/{slot}')}/next_reminder/state",
@@ -630,7 +647,7 @@ class HabitTracker(hass.Hass):
         payload = (
             "None"
             if pending is None
-            else self._parse_fire_at(pending.fire_at).isoformat()
+            else self._utc_isoformat(self._parse_fire_at(pending.fire_at))
         )
         self.mqtt.publish(
             f"{self.mqtt.topic(f'{user}/mood')}/mood_next_reminder/state",
@@ -647,10 +664,17 @@ class HabitTracker(hass.Hass):
 
     def _parse_fire_at(self, value: str) -> datetime:
         fire_at = datetime.fromisoformat(value)
-        now = self._aware_now()
+        # HA MQTT datetime commands are UTC; naive payloads must not be treated
+        # as local or schedules jump an hour early and re-fire immediately.
         if fire_at.tzinfo is None:
-            return fire_at.replace(tzinfo=now.tzinfo)
-        return fire_at.astimezone(now.tzinfo)
+            fire_at = fire_at.replace(tzinfo=UTC)
+        return fire_at.astimezone(self._aware_now().tzinfo)
+
+    @staticmethod
+    def _utc_isoformat(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat()
 
     def _aware_now(self) -> datetime:
         now = self.datetime()
@@ -707,9 +731,48 @@ class HabitTracker(hass.Hass):
             self._clear_pending(user, slot)
             self.store.save()
             return
+        # Notify immediately with the fallback so a slow/failed AI call cannot
+        # delay or swallow the reminder. Arm the next fire before waiting on AI,
+        # then upgrade the same notification_id if AI returns text.
         message = self._fallback_message(config)
+        self.log(
+            "Sending habit reminder for %s slot %s (attempt %s)",
+            user,
+            slot,
+            reminder_index,
+        )
+        self._notify_habit(user, slot, config, message)
+        last_index = final_index or config.repeat_count + 1
+        next_index = reminder_index + 1
+        now = self._aware_now()
+        if next_index <= last_index and repeat_fits_before_midnight(
+            now,
+            config.repeat_interval_minutes,
+        ):
+            fire_at = now + timedelta(minutes=config.repeat_interval_minutes)
+            pending = PendingReminder(
+                fire_at=self._utc_isoformat(fire_at),
+                next_index=next_index,
+                final_index=last_index,
+            )
+            data.pending_reminders[slot] = pending
+            self._arm_pending(user, slot, pending)
+        else:
+            self._clear_pending(user, slot)
+        self.store.save()
+        self._publish_next_reminder(user, slot)
         if config.ai_enabled:
-            message = self._ai_message(user, config, reminder_index) or message
+            ai_message = self._ai_message(user, config, reminder_index)
+            if ai_message and ai_message != message:
+                self._notify_habit(user, slot, config, ai_message)
+
+    def _notify_habit(
+        self,
+        user: str,
+        slot: int,
+        config: HabitConfig,
+        message: str,
+    ) -> None:
         action = (
             f"MARK_HABIT_AS_COMPLETE__{user.upper()}__{slot}"
             if config.habit_type is HabitType.BINARY
@@ -747,25 +810,6 @@ class HabitTracker(hass.Hass):
                 slot,
                 error,
             )
-        last_index = final_index or config.repeat_count + 1
-        next_index = reminder_index + 1
-        now = self._aware_now()
-        if next_index <= last_index and repeat_fits_before_midnight(
-            now,
-            config.repeat_interval_minutes,
-        ):
-            fire_at = now + timedelta(minutes=config.repeat_interval_minutes)
-            pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
-                next_index=next_index,
-                final_index=last_index,
-            )
-            data.pending_reminders[slot] = pending
-            self._arm_pending(user, slot, pending)
-        else:
-            self._clear_pending(user, slot)
-        self.store.save()
-        self._publish_next_reminder(user, slot)
 
     def _send_mood_reminder(
         self,
@@ -806,7 +850,7 @@ class HabitTracker(hass.Hass):
         ):
             fire_at = now + timedelta(minutes=data.mood_repeat_interval_minutes)
             pending = PendingReminder(
-                fire_at=fire_at.isoformat(),
+                fire_at=self._utc_isoformat(fire_at),
                 next_index=next_index,
                 final_index=last_index,
             )
@@ -837,19 +881,22 @@ class HabitTracker(hass.Hass):
                     "instructions": f"{AI_INSTRUCTIONS}\n\nContext:\n{context}",
                 },
                 return_response=True,
+                hass_timeout=180,
+                timeout=180,
             )
         except Exception as error:
             self.error("AI habit reminder failed: %s", error)
             return None
-        if isinstance(response, dict):
-            generated = response.get("data")
-            if isinstance(generated, str) and generated.strip():
-                return generated.strip()
-            nested = response.get("response")
+        if not isinstance(response, dict):
+            return None
+        candidates: list[object] = [response.get("data")]
+        for key in ("response", "service_response"):
+            nested = response.get(key)
             if isinstance(nested, dict):
-                generated = nested.get("data")
-                if isinstance(generated, str) and generated.strip():
-                    return generated.strip()
+                candidates.append(nested.get("data"))
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
         return None
 
     def _ai_context(

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -16,6 +16,7 @@ from .models import (
     HabitConfig,
     HabitType,
     PendingReminder,
+    UnsupportedSchemaVersionError,
     UserData,
     calculate_mood_streak,
     calculate_streak,
@@ -89,19 +90,25 @@ class HabitTracker(hass.Hass):
             return
         self.mqtt = None
         self.reminders_enabled = bool(self.args.get("reminders_enabled", False))
-        self.store = HabitStore(
-            Path(
-                str(
-                    self.args.get(
-                        "store_directory",
-                        "/homeassistant/.appdaemon/habits",
+        try:
+            self.store = HabitStore(
+                Path(
+                    str(
+                        self.args.get(
+                            "store_directory",
+                            "/homeassistant/.appdaemon/habits",
+                        ),
                     ),
                 ),
-            ),
-            self.users,
-            log=self.log,
-            error=self.error,
-        )
+                self.users,
+                log=self.log,
+                error=self.error,
+            )
+        except UnsupportedSchemaVersionError as error:
+            # Stay inert: no timers, no MQTT, no save. The on-disk store is
+            # intact and must not be overwritten by an empty one.
+            self.error("Habit tracker disabled, store is incompatible: %s", error)
+            return
         self._startup_retired: dict[str, tuple[int, ...]] = {}
         for user in self.users:
             _, retired = self._normalize_user_slots(user)

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -16,6 +16,7 @@ from .models import (
     HabitConfig,
     HabitType,
     PendingReminder,
+    UserData,
     calculate_mood_streak,
     calculate_streak,
     normalize_spare_slot,
@@ -196,7 +197,7 @@ class HabitTracker(hass.Hass):
         except (KeyError, TypeError, ValueError) as error:
             self.error("Rejected MQTT command %s=%r: %s", topic, payload, error)
 
-    def _update_habit(  # noqa: C901, PLR0912
+    def _update_habit(  # noqa: C901, PLR0912, PLR0915
         self,
         user: str,
         slot: int,
@@ -275,21 +276,50 @@ class HabitTracker(hass.Hass):
 
     def _update_mood(self, user: str, key: str, payload: str) -> None:
         data = self.store.data.users[user]
-        today = self.datetime().date().isoformat()
         if key == "mood_today":
-            if payload not in MOOD_OPTIONS:
-                raise ValueError("invalid mood option")
-            data.mood_today = payload
-            if payload != "Not Set":
-                data.mood_history[today] = payload
-            else:
-                data.mood_history.pop(today, None)
+            self._apply_mood_today(user, data, payload)
         elif key == "mood_note":
             data.mood_note = payload[:255]
+        elif key == "mood_reminder_time":
+            self._apply_mood_reminder_time(user, data, payload)
+        elif key == "mood_next_reminder":
+            self._override_mood_next_reminder(user, payload)
+            return
+        elif key == "mood_repeat_count":
+            data.mood_repeat_count = _bounded_int(payload, 0, 100)
+        elif key == "mood_repeat_interval":
+            data.mood_repeat_interval_minutes = _bounded_int(payload, 1, 1440)
         else:
             raise KeyError(key)
+        data.__post_init__()
         self.store.save()
         self._publish_mood_state(user)
+
+    def _apply_mood_today(self, user: str, data: UserData, payload: str) -> None:
+        if payload not in MOOD_OPTIONS:
+            raise ValueError("invalid mood option")
+        today = self.datetime().date().isoformat()
+        data.mood_today = payload
+        if payload != "Not Set":
+            data.mood_history[today] = payload
+            self._clear_mood_pending(user)
+            return
+        data.mood_history.pop(today, None)
+        self._seed_mood_reminder(user, force=True)
+
+    def _apply_mood_reminder_time(
+        self,
+        user: str,
+        data: UserData,
+        payload: str,
+    ) -> None:
+        time.fromisoformat(payload)
+        data.mood_reminder_time = payload
+        pending = data.pending_mood_reminder
+        if pending is not None and pending.next_index == 1:
+            self._seed_mood_reminder(user, force=True)
+        elif pending is None:
+            self._seed_mood_reminder(user)
 
     def _set_completion(self, user: str, slot: int, count: int) -> None:
         day = self.datetime().date().isoformat()
@@ -373,28 +403,56 @@ class HabitTracker(hass.Hass):
                 ),
             ),
         )
+        self.mqtt.publish(f"{prefix}/mood_reminder_time/state", data.mood_reminder_time)
+        self.mqtt.publish(
+            f"{prefix}/mood_repeat_count/state",
+            str(data.mood_repeat_count),
+        )
+        self.mqtt.publish(
+            f"{prefix}/mood_repeat_interval/state",
+            str(data.mood_repeat_interval_minutes),
+        )
+        self._publish_mood_next_reminder(user)
 
     def _restore_reminders(self) -> None:
         if not self.reminders_enabled:
             return
         for user, data in self.store.data.users.items():
-            changed = False
-            for slot, config in list(data.habits.items()):
-                pending = data.pending_reminders.get(slot)
-                if not config.configured or self._is_complete_today(user, slot):
-                    if pending is not None:
-                        self._clear_pending(user, slot)
-                        changed = True
-                    continue
-                if pending is None:
-                    self._seed_next_reminder(user, config)
-                    changed = True
-                    continue
-                self._arm_pending(user, slot, pending)
+            changed = self._restore_habit_reminders(user, data)
+            changed = self._restore_mood_reminder(user, data) or changed
             if changed:
                 self.store.save()
             for slot in data.habits:
                 self._publish_next_reminder(user, slot)
+            self._publish_mood_next_reminder(user)
+
+    def _restore_habit_reminders(self, user: str, data: UserData) -> bool:
+        changed = False
+        for slot, config in list(data.habits.items()):
+            pending = data.pending_reminders.get(slot)
+            if not config.configured or self._is_complete_today(user, slot):
+                if pending is not None:
+                    self._clear_pending(user, slot)
+                    changed = True
+                continue
+            if pending is None:
+                self._seed_next_reminder(user, config)
+                changed = True
+                continue
+            self._arm_pending(user, slot, pending)
+        return changed
+
+    def _restore_mood_reminder(self, user: str, data: UserData) -> bool:
+        if data.mood_today != "Not Set":
+            if data.pending_mood_reminder is None:
+                return False
+            self._clear_mood_pending(user)
+            return True
+        if data.pending_mood_reminder is None:
+            self._seed_mood_reminder(user)
+            return True
+        self._arm_mood_pending(user, data.pending_mood_reminder)
+        return False
 
     def _seed_next_reminder(
         self,
@@ -427,6 +485,31 @@ class HabitTracker(hass.Hass):
         self._arm_pending(user, config.slot, pending)
         self._publish_next_reminder(user, config.slot)
 
+    def _seed_mood_reminder(self, user: str, *, force: bool = False) -> None:
+        if not self.reminders_enabled:
+            return
+        data = self.store.data.users[user]
+        if data.mood_today != "Not Set":
+            self._clear_mood_pending(user)
+            return
+        if not force and data.pending_mood_reminder is not None:
+            return
+        now = self.datetime()
+        fire_at = datetime.combine(
+            now.date(),
+            time.fromisoformat(data.mood_reminder_time),
+            tzinfo=now.tzinfo,
+        )
+        fire_at = max(fire_at, now)
+        pending = PendingReminder(
+            fire_at=fire_at.isoformat(),
+            next_index=1,
+            final_index=data.mood_repeat_count + 1,
+        )
+        data.pending_mood_reminder = pending
+        self._arm_mood_pending(user, pending)
+        self._publish_mood_next_reminder(user)
+
     def _override_next_reminder(self, user: str, slot: int, payload: str) -> None:
         data = self.store.data.users[user]
         config = data.habits[slot]
@@ -456,6 +539,32 @@ class HabitTracker(hass.Hass):
         self.store.save()
         self._publish_next_reminder(user, slot)
 
+    def _override_mood_next_reminder(self, user: str, payload: str) -> None:
+        data = self.store.data.users[user]
+        if not payload.strip() or payload.strip() == "None":
+            self._clear_mood_pending(user)
+            self.store.save()
+            self._publish_mood_state(user)
+            return
+        fire_at = self._parse_fire_at(payload)
+        pending = data.pending_mood_reminder
+        if pending is None:
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=1,
+                final_index=data.mood_repeat_count + 1,
+            )
+        else:
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=pending.next_index,
+                final_index=pending.final_index,
+            )
+        data.pending_mood_reminder = pending
+        self._arm_mood_pending(user, pending)
+        self.store.save()
+        self._publish_mood_state(user)
+
     def _arm_pending(self, user: str, slot: int, pending: PendingReminder) -> None:
         if not self.reminders_enabled:
             self.reminders.cancel(user, slot)
@@ -471,10 +580,29 @@ class HabitTracker(hass.Hass):
             now=now,
         )
 
+    def _arm_mood_pending(self, user: str, pending: PendingReminder) -> None:
+        if not self.reminders_enabled:
+            self.reminders.cancel_mood(user)
+            return
+        now = self.datetime()
+        fire_at = self._parse_fire_at(pending.fire_at)
+        self.reminders.schedule_mood(
+            user,
+            fire_at=fire_at,
+            reminder_index=pending.next_index,
+            final_index=pending.final_index,
+            now=now,
+        )
+
     def _clear_pending(self, user: str, slot: int) -> None:
         self.reminders.cancel(user, slot)
         self.store.data.users[user].pending_reminders.pop(slot, None)
         self._publish_next_reminder(user, slot)
+
+    def _clear_mood_pending(self, user: str) -> None:
+        self.reminders.cancel_mood(user)
+        self.store.data.users[user].pending_mood_reminder = None
+        self._publish_mood_next_reminder(user)
 
     def _publish_next_reminder(self, user: str, slot: int) -> None:
         if self.mqtt is None:
@@ -483,6 +611,16 @@ class HabitTracker(hass.Hass):
         payload = pending.fire_at if pending is not None else "None"
         self.mqtt.publish(
             f"{self.mqtt.topic(f'{user}/{slot}')}/next_reminder/state",
+            payload,
+        )
+
+    def _publish_mood_next_reminder(self, user: str) -> None:
+        if self.mqtt is None:
+            return
+        pending = self.store.data.users[user].pending_mood_reminder
+        payload = pending.fire_at if pending is not None else "None"
+        self.mqtt.publish(
+            f"{self.mqtt.topic(f'{user}/mood')}/mood_next_reminder/state",
             payload,
         )
 
@@ -495,7 +633,7 @@ class HabitTracker(hass.Hass):
         )
 
     def _parse_fire_at(self, value: str) -> datetime:
-        fire_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        fire_at = datetime.fromisoformat(value)
         now = self.datetime()
         if fire_at.tzinfo is None and now.tzinfo is not None:
             return fire_at.replace(tzinfo=now.tzinfo)
@@ -504,6 +642,18 @@ class HabitTracker(hass.Hass):
         return fire_at
 
     def _reminder_callback(self, kwargs: dict[str, Any]) -> None:
+        if kwargs.get("kind") == "mood":
+            self._send_mood_reminder(
+                str(kwargs["user"]),
+                int(kwargs["reminder_index"]),
+                final_index=int(
+                    kwargs.get(
+                        "final_index",
+                        self.store.data.users[str(kwargs["user"])].mood_repeat_count + 1,
+                    ),
+                ),
+            )
+            return
         self._send_reminder(
             str(kwargs["user"]),
             int(kwargs["slot"]),
@@ -598,6 +748,56 @@ class HabitTracker(hass.Hass):
             self._clear_pending(user, slot)
         self.store.save()
         self._publish_next_reminder(user, slot)
+
+    def _send_mood_reminder(
+        self,
+        user: str,
+        reminder_index: int,
+        *,
+        final_index: int | None = None,
+    ) -> None:
+        if not self.reminders_enabled:
+            return
+        data = self.store.data.users[user]
+        if data.mood_today != "Not Set":
+            self._clear_mood_pending(user)
+            self.store.save()
+            return
+        user_config = self._user_config(user)
+        try:
+            self.call_service(
+                "script/turn_on",
+                entity_id=user_config["notify_script"],
+                variables={
+                    "title": "Mood Reminder",
+                    "message": "Don't forget to log how you're feeling today.",
+                    "notification_id": f"{user}_mood_reminder",
+                    "mobile_notification_icon": "mdi:emoticon-outline",
+                    "url": user_config["dashboard_url"],
+                    "actions": "[]",
+                },
+            )
+        except Exception as error:
+            self.error("Mood reminder notification failed for %s: %s", user, error)
+        last_index = final_index or data.mood_repeat_count + 1
+        next_index = reminder_index + 1
+        now = self.datetime()
+        if next_index <= last_index and repeat_fits_before_midnight(
+            now,
+            data.mood_repeat_interval_minutes,
+        ):
+            fire_at = now + timedelta(minutes=data.mood_repeat_interval_minutes)
+            pending = PendingReminder(
+                fire_at=fire_at.isoformat(),
+                next_index=next_index,
+                final_index=last_index,
+            )
+            data.pending_mood_reminder = pending
+            self._arm_mood_pending(user, pending)
+        else:
+            self._clear_mood_pending(user)
+        self.store.save()
+        self._publish_mood_next_reminder(user)
 
     def _ai_message(
         self,
@@ -862,9 +1062,11 @@ class HabitTracker(hass.Hass):
         data.mood_note = ""
         for slot in list(data.habits):
             self._clear_pending(user, slot)
+        self._clear_mood_pending(user)
         for config in data.habits.values():
             if config.configured:
                 self._seed_next_reminder(user, config, force=True)
+        self._seed_mood_reminder(user, force=True)
         self.store.save()
         self._publish_mood_state(user)
         for slot in data.habits:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -89,6 +89,8 @@ class HabitTracker(hass.Hass):
                 ),
             ),
             self.users,
+            log=self.log,
+            error=self.error,
         )
         self._startup_retired: dict[str, tuple[int, ...]] = {}
         for user in self.users:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -135,8 +135,14 @@ class HabitTracker(hass.Hass):
             self,
             self._template_dependency_changed,
             self._template_evaluation_callback,
+            self._duration_elapsed_callback,
         )
         self._watched_entities: dict[tuple[str, int], tuple[str, ...]] = {}
+        self._template_errors: dict[tuple[str, int], str | None] = {}
+        self._published_template_attributes: dict[
+            tuple[str, int],
+            dict[str, object],
+        ] = {}
         self._configure_mqtt()
         self.listen_event(
             self._handle_notification_action,
@@ -159,6 +165,13 @@ class HabitTracker(hass.Hass):
             for slot, config in data.habits.items():
                 self._rebuild_template_listeners(user, slot)
                 if config.configured and config.completion_mode.is_event_driven:
+                    if (
+                        config.completion_mode.is_duration_based
+                        and (progress := data.template_progress.get(slot)) is not None
+                    ):
+                        # Banked summed time is trusted, but an unobserved
+                        # in-flight interval across restart is not.
+                        progress.truthy_since = None
                     self._schedule_evaluation(user, slot)
 
     def terminate(self) -> None:
@@ -438,6 +451,7 @@ class HabitTracker(hass.Hass):
         elif config.configured:
             self._seed_next_reminder(user, config, force=True)
         if config.completion_mode.is_event_driven:
+            self.templates.cancel_duration(user, slot)
             progress = self._template_progress(user, slot, day)
             progress.truthy_since = None
             progress.accumulated_seconds = 0
@@ -458,6 +472,7 @@ class HabitTracker(hass.Hass):
         today = self.datetime().date()
         today_count = data.completions.get(slot, {}).get(today.isoformat(), 0)
         prefix = self.mqtt.topic(f"{user}/{slot}")
+        template_attributes = self._template_attributes(user, slot)
         self.mqtt.publish(f"{prefix}/state/state", "ON" if today_count else "OFF")
         self.mqtt.publish(f"{prefix}/count/state", str(today_count))
         stats = calculate_streak(
@@ -497,10 +512,10 @@ class HabitTracker(hass.Hass):
             f"{prefix}/name/attributes",
             {
                 **self._slot_attributes(config),
-                "completion_mode": config.completion_mode,
-                "watched_entities": list(self._watched_entities.get((user, slot), ())),
+                **template_attributes,
             },
         )
+        self._published_template_attributes[(user, slot)] = template_attributes
 
     def _publish_mood_state(self, user: str) -> None:
         if self.mqtt is None:
@@ -777,6 +792,7 @@ class HabitTracker(hass.Hass):
 
     def _rebuild_template_listeners(self, user: str, slot: int) -> None:
         """Re-subscribe a slot to the entities its template actually references."""
+        self.templates.cancel_duration(user, slot)
         config = self.store.data.users[user].habits.get(slot)
         if (
             config is None
@@ -785,6 +801,7 @@ class HabitTracker(hass.Hass):
         ):
             self.templates.remove(user, slot)
             self._watched_entities.pop((user, slot), None)
+            self._template_errors.pop((user, slot), None)
             return
         candidates = extract_candidate_entities(config.completion_template)
         # The pattern cannot distinguish an entity from an attribute access, so
@@ -826,6 +843,13 @@ class HabitTracker(hass.Hass):
         self.templates.release(user, slot)
         self._evaluate_template(user, slot)
 
+    def _duration_elapsed_callback(self, kwargs: dict[str, Any]) -> None:
+        """Re-evaluate a slot when its required truthy duration has elapsed."""
+        user = str(kwargs["user"])
+        slot = int(kwargs["slot"])
+        self.templates.release_duration(user, slot)
+        self._evaluate_template(user, slot)
+
     def _template_progress(
         self,
         user: str,
@@ -842,10 +866,12 @@ class HabitTracker(hass.Hass):
 
     def _render_truthy(self, user: str, slot: int, template: str) -> bool:
         """Render a template, treating any failure as falsy."""
+        key = (user, slot)
         try:
             rendered = self.render_template(template)
         except Exception as error:
             self.error("Habit template failed for %s slot %s: %s", user, slot, error)
+            self._template_errors[key] = str(error)
             return False
         truthy = coerce_truthy(rendered)
         if truthy is None:
@@ -855,7 +881,9 @@ class HabitTracker(hass.Hass):
                 slot,
                 rendered,
             )
+            self._template_errors[key] = f"unusable template result: {rendered!r}"
             return False
+        self._template_errors[key] = None
         return truthy
 
     def _evaluate_template(self, user: str, slot: int) -> None:
@@ -873,29 +901,148 @@ class HabitTracker(hass.Hass):
         if not config.completion_template.strip():
             return
         today = self.datetime().date().isoformat()
+        previous = data.template_progress.get(slot)
+        progress_before = (
+            previous.to_dict() if previous is not None and previous.day == today else None
+        )
         progress = self._template_progress(user, slot, today)
         if progress.suppressed_day == today:
+            self.templates.cancel_duration(user, slot)
+            self._save_template_progress_if_changed(progress, progress_before)
+            self._publish_template_attributes_if_changed(user, slot)
             return
         if self._is_complete_today(user, slot):
+            self.templates.cancel_duration(user, slot)
             progress.truthy_since = None
             progress.accumulated_seconds = 0
-            self.store.save()
+            self._save_template_progress_if_changed(progress, progress_before)
+            self._publish_template_attributes_if_changed(user, slot)
             return
-        was_truthy = progress.is_truthy
+        now = self._aware_now()
         now_truthy = self._render_truthy(user, slot, config.completion_template)
-        progress.truthy_since = (
-            self._utc_isoformat(self._aware_now()) if now_truthy else None
-        )
-        if (
-            config.completion_mode is CompletionMode.INSTANT
-            and now_truthy
-            and not was_truthy
-        ):
+        if config.completion_mode is CompletionMode.INSTANT:
+            completed = self._apply_instant_mode(
+                user,
+                slot,
+                progress,
+                now_truthy=now_truthy,
+                now=now,
+            )
+        else:
+            completed = self._apply_duration_mode(
+                user,
+                slot,
+                config,
+                progress,
+                now_truthy=now_truthy,
+                now=now,
+            )
+        if completed:
             self.log("Habit template completed %s slot %s", user, slot)
-            # _set_completion persists and republishes.
             self._set_completion(user, slot, 1)
         else:
+            self._save_template_progress_if_changed(progress, progress_before)
+            self._publish_template_attributes_if_changed(user, slot)
+
+    def _apply_instant_mode(
+        self,
+        user: str,
+        slot: int,
+        progress: TemplateProgress,
+        *,
+        now_truthy: bool,
+        now: datetime,
+    ) -> bool:
+        """Apply rising-edge completion for an instant-mode slot."""
+        self.templates.cancel_duration(user, slot)
+        was_truthy = progress.is_truthy
+        progress.truthy_since = self._utc_isoformat(now) if now_truthy else None
+        return now_truthy and not was_truthy
+
+    def _apply_duration_mode(
+        self,
+        user: str,
+        slot: int,
+        config: HabitConfig,
+        progress: TemplateProgress,
+        *,
+        now_truthy: bool,
+        now: datetime,
+    ) -> bool:
+        """Bank elapsed truthy time and arm the remaining duration."""
+        elapsed = self._elapsed_truthy_seconds(progress, now)
+        if not now_truthy:
+            if progress.is_truthy and config.completion_mode is CompletionMode.SUMMED:
+                progress.accumulated_seconds += elapsed
+            progress.truthy_since = None
+            self.templates.cancel_duration(user, slot)
+            return False
+        if not progress.is_truthy:
+            progress.truthy_since = self._utc_isoformat(now)
+            elapsed = 0
+        counted = elapsed
+        if config.completion_mode is CompletionMode.SUMMED:
+            counted += progress.accumulated_seconds
+        remaining = config.completion_duration_minutes * 60 - counted
+        if remaining <= 0:
+            self.templates.cancel_duration(user, slot)
+            return True
+        self.templates.arm_duration(user, slot, remaining)
+        return False
+
+    def _elapsed_truthy_seconds(
+        self,
+        progress: TemplateProgress,
+        now: datetime,
+    ) -> int:
+        """Return whole elapsed truthy seconds, clamped against clock skew."""
+        if progress.truthy_since is None:
+            return 0
+        truthy_since = self._parse_fire_at(progress.truthy_since)
+        return max(0, int((now - truthy_since).total_seconds()))
+
+    def _save_template_progress_if_changed(
+        self,
+        progress: TemplateProgress,
+        previous: dict[str, Any] | None,
+    ) -> None:
+        """Persist template progress only when its durable state changed."""
+        if progress.to_dict() != previous:
             self.store.save()
+
+    def _publish_template_attributes_if_changed(self, user: str, slot: int) -> None:
+        """Republish a slot only when its template attributes changed."""
+        attributes = self._template_attributes(user, slot)
+        if self._published_template_attributes.get((user, slot)) != attributes:
+            self._publish_habit_state(user, slot)
+
+    def _template_attributes(self, user: str, slot: int) -> dict[str, object]:
+        """Build the observable state of a slot's completion template."""
+        data = self.store.data.users[user]
+        config = data.habits[slot]
+        today = self.datetime().date().isoformat()
+        progress = data.template_progress.get(slot)
+        if progress is not None and progress.day != today:
+            progress = None
+        attributes: dict[str, object] = {
+            "completion_mode": config.completion_mode,
+            "condition": progress.is_truthy if progress is not None else False,
+            "template_error": self._template_errors.get((user, slot)),
+            "watched_entities": list(self._watched_entities.get((user, slot), ())),
+        }
+        if config.completion_mode.is_duration_based:
+            seconds = 0
+            if progress is not None:
+                if config.completion_mode is CompletionMode.SUMMED:
+                    seconds = progress.accumulated_seconds
+                seconds += self._elapsed_truthy_seconds(progress, self._aware_now())
+            attributes.update(
+                {
+                    "condition_minutes": round(seconds / 60, 2),
+                    "condition_target_minutes": config.completion_duration_minutes,
+                },
+            )
+        return attributes
 
     def _is_complete_today(self, user: str, slot: int) -> bool:
         return (
@@ -1391,6 +1538,7 @@ class HabitTracker(hass.Hass):
         # next evaluation rather than cleared here.
         for slot, config in data.habits.items():
             if config.configured and config.completion_mode.is_event_driven:
+                self.templates.cancel_duration(user, slot)
                 self._schedule_evaluation(user, slot)
         self.store.save()
         self._publish_mood_state(user)
@@ -1411,6 +1559,8 @@ class HabitTracker(hass.Hass):
             with suppress(AttributeError):
                 self.templates.remove(user, slot)
             self._watched_entities.pop((user, slot), None)
+            self._template_errors.pop((user, slot), None)
+            self._published_template_attributes.pop((user, slot), None)
         return added_spare, retired
 
     def _validate_config(self) -> bool:  # noqa: C901, PLR0912

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -39,7 +39,8 @@ Requirements:
 - One or two short sentences maximum
 - Mention the habit name naturally
 - Do not address the recipient by name or with a personal greeting
-- Use the provided context only when it changes what a useful reminder would say
+- Use provided context only when it is directly relevant to this habit and changes
+  what a useful reminder would say; otherwise ignore it
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_AI_INSTRUCTIONS: Final[str] = """Write one short mood check-in reminder notification
@@ -53,7 +54,8 @@ Requirements:
 - One or two short sentences maximum
 - Ask the recipient to log how they are feeling today
 - Do not address the recipient by name or with a personal greeting
-- Use the provided context only when it changes what a useful reminder would say
+- Use provided context only when it is directly relevant to logging mood and changes
+  what a useful reminder would say; otherwise ignore it
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_FALLBACK_MESSAGE: Final[str] = "Don't forget to log how you're feeling today."
@@ -65,9 +67,7 @@ REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
     "at_work_entity",
     "workday_entity",
     "activity_entity",
-    "steps_entity",
     "weather_entity",
-    "sun_entity",
 )
 SLOT_TOPIC_PARTS: Final[int] = 4
 ACTION_PARTS: Final[int] = 3
@@ -795,7 +795,7 @@ class HabitTracker(hass.Hass):
 
         message = self._fallback_message(config)
         if config.ai_enabled:
-            message = self._ai_message(user, config, reminder_index) or message
+            message = self._ai_message(user, config) or message
         self.log(
             "Sending habit reminder for %s slot %s (attempt %s)",
             user,
@@ -887,7 +887,7 @@ class HabitTracker(hass.Hass):
         self.store.save()
         self._publish_mood_next_reminder(user)
 
-        message = self._ai_mood_message(user, reminder_index) or MOOD_FALLBACK_MESSAGE
+        message = self._ai_mood_message(user) or MOOD_FALLBACK_MESSAGE
         self.log("Sending mood reminder for %s (attempt %s)", user, reminder_index)
         self._notify_mood(user, message)
 
@@ -909,24 +909,19 @@ class HabitTracker(hass.Hass):
         except Exception as error:
             self.error("Mood reminder notification failed for %s: %s", user, error)
 
-    def _ai_message(
-        self,
-        user: str,
-        config: HabitConfig,
-        reminder_index: int,
-    ) -> str | None:
+    def _ai_message(self, user: str, config: HabitConfig) -> str | None:
         return self._generate_ai_message(
             task_name=(f"habit reminder {user}_habit_{config.habit_type}_{config.slot}"),
             instructions=AI_INSTRUCTIONS,
-            context=self._ai_context(user, config, reminder_index),
+            context=self._ai_context(user, config),
             kind="habit",
         )
 
-    def _ai_mood_message(self, user: str, reminder_index: int) -> str | None:
+    def _ai_mood_message(self, user: str) -> str | None:
         return self._generate_ai_message(
             task_name=f"mood reminder {user}",
             instructions=MOOD_AI_INSTRUCTIONS,
-            context=self._ai_mood_context(user, reminder_index),
+            context=self._ai_mood_context(user),
             kind="mood",
         )
 
@@ -964,12 +959,7 @@ class HabitTracker(hass.Hass):
             )
         return message
 
-    def _ai_context(
-        self,
-        user: str,
-        config: HabitConfig,
-        reminder_index: int,
-    ) -> str:
+    def _ai_context(self, user: str, config: HabitConfig) -> str:
         data = self.store.data.users[user]
         user_config = self._user_config(user)
         now = self._aware_now()
@@ -977,14 +967,6 @@ class HabitTracker(hass.Hass):
             data.completions.get(config.slot, {}),
             today=now.date(),
             min_days_per_week=config.streak_min_days_per_week,
-        )
-        repeat_total = config.repeat_count + 1
-        attempt = (
-            "first reminder today"
-            if reminder_index == 1
-            else f"final reminder today (attempt {reminder_index})"
-            if reminder_index >= repeat_total
-            else f"repeat reminder {reminder_index} of {repeat_total}"
         )
         pairs: list[tuple[str, object]] = [
             ("Habit name", config.name),
@@ -1006,17 +988,8 @@ class HabitTracker(hass.Hass):
                 "Current physical activity",
                 self._state_value(str(user_config["activity_entity"])),
             ),
-            (
-                "Steps so far today",
-                self._numeric_state(str(user_config["steps_entity"]), integer=True),
-            ),
             ("Weather", self._weather_summary(str(user_config["weather_entity"]))),
-            (
-                "Daylight remaining minutes",
-                self._daylight_minutes(str(user_config["sun_entity"]), now),
-            ),
             ("Local date", _local_date_label(now)),
-            ("Reminder attempt", attempt),
         ]
         return "\n".join(
             f"- {label}: {value}"
@@ -1024,18 +997,10 @@ class HabitTracker(hass.Hass):
             if value not in INVALID_STATES and value not in {"Not Set", -1}
         )
 
-    def _ai_mood_context(self, user: str, reminder_index: int) -> str:
+    def _ai_mood_context(self, user: str) -> str:
         data = self.store.data.users[user]
         user_config = self._user_config(user)
         now = self._aware_now()
-        repeat_total = data.mood_repeat_count + 1
-        attempt = (
-            "first reminder today"
-            if reminder_index == 1
-            else f"final reminder today (attempt {reminder_index})"
-            if reminder_index >= repeat_total
-            else f"repeat reminder {reminder_index} of {repeat_total}"
-        )
         pairs: list[tuple[str, object]] = [
             ("Mood today", data.mood_today),
             (
@@ -1051,7 +1016,6 @@ class HabitTracker(hass.Hass):
                 else "no",
             ),
             ("Local date", _local_date_label(now)),
-            ("Reminder attempt", attempt),
         ]
         return "\n".join(
             f"- {label}: {value}"
@@ -1157,34 +1121,12 @@ class HabitTracker(hass.Hass):
             return ""
         return value
 
-    def _numeric_state(
-        self,
-        entity_id: str,
-        *,
-        integer: bool = False,
-    ) -> str | int | float:
-        value = self._state_value(entity_id)
-        try:
-            numeric = float(value)
-        except (TypeError, ValueError):
-            return ""
-        return int(numeric) if integer else numeric
-
     def _weather_summary(self, entity_id: str) -> str:
         condition = self._state_value(entity_id)
         temperature = self.get_state(entity_id, attribute="temperature")
-        if condition == "" or temperature in INVALID_STATES:
+        if not condition or temperature in INVALID_STATES:
             return ""
         return f"{condition}, {temperature}°C"
-
-    def _daylight_minutes(self, entity_id: str, now: datetime) -> int:
-        if self.get_state(entity_id) != "above_horizon":
-            return 0
-        parsed = _event_datetime(
-            self.get_state(entity_id, attribute="next_setting"),
-            now,
-        )
-        return 0 if parsed is None else max(0, round((parsed - now).total_seconds() / 60))
 
     @staticmethod
     def _fallback_message(config: HabitConfig) -> str:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -761,20 +761,12 @@ class HabitTracker(hass.Hass):
             self._clear_pending(user, slot)
             self.store.save()
             return
-        # Notify immediately with the fallback so a slow/failed AI call cannot
-        # delay or swallow the reminder. Arm the next fire before waiting on AI,
-        # then upgrade the same notification_id if AI returns text.
-        message = self._fallback_message(config)
-        self.log(
-            "Sending habit reminder for %s slot %s (attempt %s)",
-            user,
-            slot,
-            reminder_index,
-        )
-        self._notify_habit(user, slot, config, message)
+        # Arm the next fire before waiting on AI so a slow model cannot push the
+        # schedule out. Only send one notification: AI text when available,
+        # otherwise the deterministic fallback.
+        now = self._aware_now()
         last_index = final_index or config.repeat_count + 1
         next_index = reminder_index + 1
-        now = self._aware_now()
         if next_index <= last_index and repeat_fits_before_midnight(
             now,
             config.repeat_interval_minutes,
@@ -791,10 +783,17 @@ class HabitTracker(hass.Hass):
             self._clear_pending(user, slot)
         self.store.save()
         self._publish_next_reminder(user, slot)
+
+        message = self._fallback_message(config)
         if config.ai_enabled:
-            ai_message = self._ai_message(user, config, reminder_index)
-            if ai_message and ai_message != message:
-                self._notify_habit(user, slot, config, ai_message)
+            message = self._ai_message(user, config, reminder_index) or message
+        self.log(
+            "Sending habit reminder for %s slot %s (attempt %s)",
+            user,
+            slot,
+            reminder_index,
+        )
+        self._notify_habit(user, slot, config, message)
 
     def _notify_habit(
         self,

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -39,14 +39,7 @@ Requirements:
 - One or two short sentences maximum
 - Mention the habit name naturally
 - Do not address the recipient by name or with a personal greeting
-- You may mention streak, mood, completion rate, or that this is a repeat reminder
-  when that context is useful
-- Use location only when it materially affects whether the habit is feasible right
-  now. For example, do not encourage doing skincare immediately when the user is at
-  work; still give a useful reminder, such as doing it later or keeping a streak in mind
-- If the user is in a meeting or has only a short free window, suggest a realistic
-  later time instead of interrupting them
-- Use weather and daylight only when they materially affect an outdoor habit
+- Use the provided context only when it changes what a useful reminder would say
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_AI_INSTRUCTIONS: Final[str] = """Write one short mood check-in reminder notification
@@ -60,9 +53,7 @@ Requirements:
 - One or two short sentences maximum
 - Ask the recipient to log how they are feeling today
 - Do not address the recipient by name or with a personal greeting
-- You may mention mood streak or that this is a repeat reminder when useful
-- If the user is in a meeting or has only a short free window, suggest a realistic
-  later time instead of interrupting them
+- Use the provided context only when it changes what a useful reminder would say
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_FALLBACK_MESSAGE: Final[str] = "Don't forget to log how you're feeling today."

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -45,8 +45,11 @@ Requirements:
 - One or two short sentences maximum
 - Mention the habit name naturally
 - Do not address the recipient by name or with a personal greeting
-- Use provided context only when it is directly relevant to this habit and changes
-  what a useful reminder would say; otherwise ignore it
+- Treat the provided context as private guidance for choosing an appropriate reminder,
+  not content to repeat to the recipient
+- Do not state, summarize, or open with contextual facts such as the time, day, date,
+  month, location, work status, calendar availability, activity, weather, or mood
+- Use context only when it materially changes what a useful reminder would say
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_AI_INSTRUCTIONS: Final[str] = """Write one short mood check-in reminder notification
@@ -60,8 +63,11 @@ Requirements:
 - One or two short sentences maximum
 - Ask the recipient to log how they are feeling today
 - Do not address the recipient by name or with a personal greeting
-- Use provided context only when it is directly relevant to logging mood and changes
-  what a useful reminder would say; otherwise ignore it
+- Treat the provided context as private guidance for choosing an appropriate reminder,
+  not content to repeat to the recipient
+- Do not state, summarize, or open with contextual facts such as the time, day, date,
+  month, location, work status, calendar availability, activity, weather, or mood
+- Use context only when it materially changes what a useful reminder would say
 - Do not name specific places, addresses, or coordinates
 - Do not include markdown, emojis, quotes, or a title"""
 MOOD_FALLBACK_MESSAGE: Final[str] = "Don't forget to log how you're feeling today."

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -288,6 +288,9 @@ class HabitTracker(hass.Hass):
             data.mood_note = payload[:255]
         elif key == "mood_reminder_time":
             self._apply_mood_reminder_time(user, data, payload)
+        elif key == "mood_reminders":
+            self._apply_mood_reminders_enabled(user, data, enabled=_mqtt_bool(payload))
+            return
         elif key == "mood_next_reminder":
             self._override_mood_next_reminder(user, payload)
             return
@@ -326,6 +329,21 @@ class HabitTracker(hass.Hass):
             self._seed_mood_reminder(user, force=True)
         elif pending is None:
             self._seed_mood_reminder(user)
+
+    def _apply_mood_reminders_enabled(
+        self,
+        user: str,
+        data: UserData,
+        *,
+        enabled: bool,
+    ) -> None:
+        data.mood_reminders_enabled = enabled
+        if enabled:
+            self._seed_mood_reminder(user, force=True)
+        else:
+            self._clear_mood_pending(user)
+        self.store.save()
+        self._publish_mood_state(user)
 
     def _set_completion(self, user: str, slot: int, count: int) -> None:
         day = self.datetime().date().isoformat()
@@ -411,6 +429,10 @@ class HabitTracker(hass.Hass):
         )
         self.mqtt.publish(f"{prefix}/mood_reminder_time/state", data.mood_reminder_time)
         self.mqtt.publish(
+            f"{prefix}/mood_reminders/state",
+            "ON" if data.mood_reminders_enabled else "OFF",
+        )
+        self.mqtt.publish(
             f"{prefix}/mood_repeat_count/state",
             str(data.mood_repeat_count),
         )
@@ -449,7 +471,7 @@ class HabitTracker(hass.Hass):
         return changed
 
     def _restore_mood_reminder(self, user: str, data: UserData) -> bool:
-        if data.mood_today != "Not Set":
+        if not data.mood_reminders_enabled or data.mood_today != "Not Set":
             if data.pending_mood_reminder is None:
                 return False
             self._clear_mood_pending(user)
@@ -495,6 +517,9 @@ class HabitTracker(hass.Hass):
         if not self.reminders_enabled:
             return
         data = self.store.data.users[user]
+        if not data.mood_reminders_enabled:
+            self._clear_mood_pending(user)
+            return
         if data.mood_today != "Not Set":
             self._clear_mood_pending(user)
             return
@@ -560,6 +585,8 @@ class HabitTracker(hass.Hass):
             self.store.save()
             self._publish_mood_state(user)
             return
+        if not data.mood_reminders_enabled:
+            raise ValueError("mood reminders are disabled")
         fire_at = self._parse_fire_at(payload)
         pending = data.pending_mood_reminder
         if (
@@ -603,7 +630,10 @@ class HabitTracker(hass.Hass):
         )
 
     def _arm_mood_pending(self, user: str, pending: PendingReminder) -> None:
-        if not self.reminders_enabled:
+        if (
+            not self.reminders_enabled
+            or not self.store.data.users[user].mood_reminders_enabled
+        ):
             self.reminders.cancel_mood(user)
             return
         now = self._aware_now()
@@ -821,6 +851,10 @@ class HabitTracker(hass.Hass):
         if not self.reminders_enabled:
             return
         data = self.store.data.users[user]
+        if not data.mood_reminders_enabled:
+            self._clear_mood_pending(user)
+            self.store.save()
+            return
         if data.mood_today != "Not Set":
             self._clear_mood_pending(user)
             self.store.save()
@@ -887,17 +921,13 @@ class HabitTracker(hass.Hass):
         except Exception as error:
             self.error("AI habit reminder failed: %s", error)
             return None
-        if not isinstance(response, dict):
-            return None
-        candidates: list[object] = [response.get("data")]
-        for key in ("response", "service_response"):
-            nested = response.get(key)
-            if isinstance(nested, dict):
-                candidates.append(nested.get("data"))
-        for candidate in candidates:
-            if isinstance(candidate, str) and candidate.strip():
-                return candidate.strip()
-        return None
+        message = _ai_response_text(response)
+        if message is None:
+            self.error(
+                "AI habit reminder returned no usable text (response=%r)",
+                response,
+            )
+        return message
 
     def _ai_context(
         self,
@@ -1014,11 +1044,12 @@ class HabitTracker(hass.Hass):
         except Exception as error:
             self.error("Calendar context failed for %s: %s", user, error)
             return ""
-        if not isinstance(response, dict):
+        payload = _service_result(response)
+        if payload is None:
             return ""
         busy_until: datetime | None = None
         next_start: datetime | None = None
-        for calendar in response.values():
+        for calendar in payload.values():
             if not isinstance(calendar, dict) or not isinstance(
                 calendar.get("events"),
                 list,
@@ -1247,6 +1278,33 @@ def _mqtt_bool(payload: str) -> bool:
     if normalized in {"off", "false", "0"}:
         return False
     raise ValueError("expected an on/off value")
+
+
+def _service_result(response: object) -> dict[str, Any] | None:
+    """Unwrap AppDaemon's call_service envelope to the Home Assistant result body."""
+    if not isinstance(response, dict):
+        return None
+    if response.get("success") is False:
+        return None
+    result = response.get("result")
+    if isinstance(result, dict):
+        return cast("dict[str, Any]", result)
+    return cast("dict[str, Any]", response)
+
+
+def _ai_response_text(response: object) -> str | None:
+    payload = _service_result(response)
+    if payload is None:
+        return None
+    candidates: list[object] = [payload.get("data")]
+    for key in ("response", "service_response", "result"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            candidates.append(nested.get("data"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
 
 
 def _bounded_int(payload: str, minimum: int, maximum: int) -> int:

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -469,7 +469,7 @@ class HabitTracker(hass.Hass):
         data = self.store.data.users[user]
         if not force and config.slot in data.pending_reminders:
             return
-        now = self.datetime()
+        now = self._aware_now()
         fire_at = datetime.combine(
             now.date(),
             time.fromisoformat(config.reminder_time),
@@ -494,7 +494,7 @@ class HabitTracker(hass.Hass):
             return
         if not force and data.pending_mood_reminder is not None:
             return
-        now = self.datetime()
+        now = self._aware_now()
         fire_at = datetime.combine(
             now.date(),
             time.fromisoformat(data.mood_reminder_time),
@@ -569,7 +569,7 @@ class HabitTracker(hass.Hass):
         if not self.reminders_enabled:
             self.reminders.cancel(user, slot)
             return
-        now = self.datetime()
+        now = self._aware_now()
         fire_at = self._parse_fire_at(pending.fire_at)
         self.reminders.schedule_at(
             user,
@@ -584,7 +584,7 @@ class HabitTracker(hass.Hass):
         if not self.reminders_enabled:
             self.reminders.cancel_mood(user)
             return
-        now = self.datetime()
+        now = self._aware_now()
         fire_at = self._parse_fire_at(pending.fire_at)
         self.reminders.schedule_mood(
             user,
@@ -608,7 +608,11 @@ class HabitTracker(hass.Hass):
         if self.mqtt is None:
             return
         pending = self.store.data.users[user].pending_reminders.get(slot)
-        payload = pending.fire_at if pending is not None else "None"
+        payload = (
+            "None"
+            if pending is None
+            else self._parse_fire_at(pending.fire_at).isoformat()
+        )
         self.mqtt.publish(
             f"{self.mqtt.topic(f'{user}/{slot}')}/next_reminder/state",
             payload,
@@ -618,7 +622,11 @@ class HabitTracker(hass.Hass):
         if self.mqtt is None:
             return
         pending = self.store.data.users[user].pending_mood_reminder
-        payload = pending.fire_at if pending is not None else "None"
+        payload = (
+            "None"
+            if pending is None
+            else self._parse_fire_at(pending.fire_at).isoformat()
+        )
         self.mqtt.publish(
             f"{self.mqtt.topic(f'{user}/mood')}/mood_next_reminder/state",
             payload,
@@ -634,37 +642,42 @@ class HabitTracker(hass.Hass):
 
     def _parse_fire_at(self, value: str) -> datetime:
         fire_at = datetime.fromisoformat(value)
-        now = self.datetime()
-        if fire_at.tzinfo is None and now.tzinfo is not None:
+        now = self._aware_now()
+        if fire_at.tzinfo is None:
             return fire_at.replace(tzinfo=now.tzinfo)
-        if fire_at.tzinfo is not None and now.tzinfo is None:
-            return fire_at.replace(tzinfo=None)
-        return fire_at
+        return fire_at.astimezone(now.tzinfo)
+
+    def _aware_now(self) -> datetime:
+        now = self.datetime()
+        if now.tzinfo is not None:
+            return now
+        return now.replace(tzinfo=datetime.now().astimezone().tzinfo)
 
     def _reminder_callback(self, kwargs: dict[str, Any]) -> None:
+        user = str(kwargs["user"])
         if kwargs.get("kind") == "mood":
+            self.reminders.release_mood(user)
             self._send_mood_reminder(
-                str(kwargs["user"]),
+                user,
                 int(kwargs["reminder_index"]),
                 final_index=int(
                     kwargs.get(
                         "final_index",
-                        self.store.data.users[str(kwargs["user"])].mood_repeat_count + 1,
+                        self.store.data.users[user].mood_repeat_count + 1,
                     ),
                 ),
             )
             return
+        slot = int(kwargs["slot"])
+        self.reminders.release(user, slot)
         self._send_reminder(
-            str(kwargs["user"]),
-            int(kwargs["slot"]),
+            user,
+            slot,
             int(kwargs["reminder_index"]),
             final_index=int(
                 kwargs.get(
                     "final_index",
-                    self.store.data.users[str(kwargs["user"])]
-                    .habits[int(kwargs["slot"])]
-                    .repeat_count
-                    + 1,
+                    self.store.data.users[user].habits[slot].repeat_count + 1,
                 ),
             ),
         )
@@ -731,7 +744,7 @@ class HabitTracker(hass.Hass):
             )
         last_index = final_index or config.repeat_count + 1
         next_index = reminder_index + 1
-        now = self.datetime()
+        now = self._aware_now()
         if next_index <= last_index and repeat_fits_before_midnight(
             now,
             config.repeat_interval_minutes,
@@ -781,7 +794,7 @@ class HabitTracker(hass.Hass):
             self.error("Mood reminder notification failed for %s: %s", user, error)
         last_index = final_index or data.mood_repeat_count + 1
         next_index = reminder_index + 1
-        now = self.datetime()
+        now = self._aware_now()
         if next_index <= last_index and repeat_fits_before_midnight(
             now,
             data.mood_repeat_interval_minutes,
@@ -833,7 +846,7 @@ class HabitTracker(hass.Hass):
     ) -> str:
         data = self.store.data.users[user]
         user_config = self._user_config(user)
-        now = self.datetime()
+        now = self._aware_now()
         stats = calculate_streak(
             data.completions.get(config.slot, {}),
             today=now.date(),
@@ -1193,4 +1206,8 @@ def _event_datetime(value: object, now: datetime) -> datetime | None:
         parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=now.tzinfo)
+    if now.tzinfo is None:
+        return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=now.tzinfo)
+    return parsed.astimezone(now.tzinfo)

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -58,7 +58,6 @@ REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
     "weather_entity",
     "sun_entity",
 )
-TEST_TOPIC_PARTS: Final[int] = 3
 SLOT_TOPIC_PARTS: Final[int] = 4
 ACTION_PARTS: Final[int] = 3
 MAX_NETWORK_PORT: Final[int] = 65535
@@ -174,7 +173,6 @@ class HabitTracker(hass.Hass):
             return
         self.mqtt.publish_mood_discovery(self.users)
         for user in self.users:
-            self.mqtt.publish_user_discovery(user)
             for retired_slot in self._startup_retired[user]:
                 self.mqtt.retire_slot(user, retired_slot)
             for config in self.store.data.users[user].habits.values():
@@ -190,9 +188,7 @@ class HabitTracker(hass.Hass):
             return
         parts = topic[len(prefix) :].split("/")
         try:
-            if len(parts) == TEST_TOPIC_PARTS and parts[1] == "test":
-                self._send_test_reminder(parts[0])
-            elif len(parts) == SLOT_TOPIC_PARTS and parts[1] == "mood":
+            if len(parts) == SLOT_TOPIC_PARTS and parts[1] == "mood":
                 self._update_mood(parts[0], parts[2], payload)
             elif len(parts) == SLOT_TOPIC_PARTS:
                 self._update_habit(parts[0], int(parts[1]), parts[2], payload)
@@ -391,9 +387,8 @@ class HabitTracker(hass.Hass):
         reminder_index: int,
         *,
         final_index: int | None = None,
-        force: bool = False,
     ) -> None:
-        if not force and not self.reminders_enabled:
+        if not self.reminders_enabled:
             return
         data = self.store.data.users[user]
         config = data.habits.get(slot)
@@ -448,35 +443,15 @@ class HabitTracker(hass.Hass):
                 slot,
                 error,
             )
-        if not force:
-            last_index = final_index or config.repeat_count + 1
-            self.reminders.schedule_next_repeat(
-                user,
-                slot,
-                next_index=reminder_index + 1,
-                final_index=last_index,
-                interval_minutes=config.repeat_interval_minutes,
-                now=self.datetime(),
-            )
-
-    def _send_test_reminder(self, user: str) -> None:
-        """Test the lowest numbered configured incomplete habit."""
-        today = self.datetime().date().isoformat()
-        data = self.store.data.users[user]
-        candidates = sorted(
-            config.slot
-            for config in data.habits.values()
-            if config.configured
-            and data.completions.get(config.slot, {}).get(today, 0) == 0
+        last_index = final_index or config.repeat_count + 1
+        self.reminders.schedule_next_repeat(
+            user,
+            slot,
+            next_index=reminder_index + 1,
+            final_index=last_index,
+            interval_minutes=config.repeat_interval_minutes,
+            now=self.datetime(),
         )
-        if not candidates:
-            self.log(
-                "No configured incomplete habit available for %s test reminder",
-                user,
-                level="WARNING",
-            )
-            return
-        self._send_reminder(user, candidates[0], 1, force=True)
 
     def _ai_message(
         self,

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, time, timedelta
 from enum import StrEnum
-from typing import Any, Final, Self
+from typing import TYPE_CHECKING, Any, Final, Self
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 SCHEMA_VERSION: Final[int] = 1
+MIN_SCHEMA_VERSION: Final[int] = 1
 MAX_NAME_LENGTH: Final[int] = 255
 MAX_REPEAT_COUNT: Final[int] = 100
 MAX_REPEAT_INTERVAL: Final[int] = 1440
@@ -21,6 +25,22 @@ MOOD_OPTIONS: Final[tuple[str, ...]] = (
     "Good",
     "Great",
 )
+
+
+class UnsupportedSchemaVersionError(ValueError):
+    """Raised when a persisted store cannot be parsed by this build.
+
+    Distinct from a corrupt store: the file is structurally intact, it just
+    carries a version this code does not know how to read. Callers must not
+    quarantine or overwrite it.
+    """
+
+    def __init__(self, version: int) -> None:
+        super().__init__(
+            f"unsupported schema version: {version} "
+            f"(this build supports {MIN_SCHEMA_VERSION}-{SCHEMA_VERSION})",
+        )
+        self.version = version
 
 
 class HabitType(StrEnum):
@@ -242,6 +262,32 @@ class UserData:
         )
 
 
+# Upgrade steps keyed by source version; entry N migrates a payload from
+# version N to version N+1. Register a step in the same change that bumps
+# SCHEMA_VERSION.
+SCHEMA_MIGRATIONS: Final[dict[int, Callable[[dict[str, Any]], dict[str, Any]]]] = {}
+
+
+def migrate_store_payload(
+    value: dict[str, Any],
+    *,
+    from_version: int,
+) -> dict[str, Any]:
+    """Upgrade a raw store payload to the current schema version.
+
+    A missing step is fatal rather than silently skipped, so a forgotten
+    migration surfaces as a refusal to start instead of as data loss.
+    """
+    migrated = dict(value)
+    for version in range(from_version, SCHEMA_VERSION):
+        step = SCHEMA_MIGRATIONS.get(version)
+        if step is None:
+            raise UnsupportedSchemaVersionError(from_version)
+        migrated = step(migrated)
+        migrated["schema_version"] = version + 1
+    return migrated
+
+
 @dataclass(slots=True)
 class StoreData:
     """Top-level versioned persistence schema."""
@@ -265,17 +311,19 @@ class StoreData:
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> Self:
-        """Parse the current schema, rejecting unsupported versions."""
+        """Parse any supported schema version, upgrading older payloads first."""
         version = _integer(value, "schema_version")
-        if version != SCHEMA_VERSION:
-            raise ValueError(f"unsupported schema version: {version}")
+        if not MIN_SCHEMA_VERSION <= version <= SCHEMA_VERSION:
+            raise UnsupportedSchemaVersionError(version)
+        if version < SCHEMA_VERSION:
+            value = migrate_store_payload(value, from_version=version)
         users = {
             str(user): UserData.from_dict(_dict(data))
             for user, data in _mapping(value, "users").items()
         }
         return cls(
             users=users,
-            schema_version=version,
+            schema_version=SCHEMA_VERSION,
         )
 
 

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -502,6 +502,12 @@ def normalize_spare_slot(data: UserData) -> tuple[int | None, tuple[int, ...]]:
     added_spare: int | None = None
     if empty_slots:
         spare_slot = empty_slots[0]
+        # An empty slot may be a deleted habit. Reset it so the next habit does
+        # not inherit its old completion mode, template, icons, or reminders.
+        data.habits[spare_slot] = HabitConfig(slot=spare_slot)
+        data.completions.pop(spare_slot, None)
+        data.pending_reminders.pop(spare_slot, None)
+        data.template_progress.pop(spare_slot, None)
     else:
         spare_slot = 1
         while spare_slot in data.habits:

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -145,6 +145,7 @@ class UserData:
     mood_today: str = "Not Set"
     mood_note: str = ""
     mood_reminder_time: str = "20:00:00"
+    mood_reminders_enabled: bool = True
     mood_repeat_count: int = 0
     mood_repeat_interval_minutes: int = 60
     pending_mood_reminder: PendingReminder | None = None
@@ -179,6 +180,7 @@ class UserData:
             "mood_today": self.mood_today,
             "mood_note": self.mood_note,
             "mood_reminder_time": self.mood_reminder_time,
+            "mood_reminders_enabled": self.mood_reminders_enabled,
             "mood_repeat_count": self.mood_repeat_count,
             "mood_repeat_interval_minutes": self.mood_repeat_interval_minutes,
             "pending_mood_reminder": (
@@ -225,6 +227,11 @@ class UserData:
             mood_today=_mood(value.get("mood_today", "Not Set")),
             mood_note=_string(value, "mood_note", ""),
             mood_reminder_time=_string(value, "mood_reminder_time", "20:00:00"),
+            mood_reminders_enabled=_boolean(
+                value,
+                "mood_reminders_enabled",
+                default=True,
+            ),
             mood_repeat_count=_integer(value, "mood_repeat_count", 0),
             mood_repeat_interval_minutes=_integer(
                 value,

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -144,6 +144,23 @@ class UserData:
     mood_history: dict[str, str] = field(default_factory=dict)
     mood_today: str = "Not Set"
     mood_note: str = ""
+    mood_reminder_time: str = "20:00:00"
+    mood_repeat_count: int = 0
+    mood_repeat_interval_minutes: int = 60
+    pending_mood_reminder: PendingReminder | None = None
+
+    def __post_init__(self) -> None:
+        """Reject malformed mood reminder configuration."""
+        if not 0 <= self.mood_repeat_count <= MAX_REPEAT_COUNT:
+            raise ValueError("mood_repeat_count must be between 0 and 100")
+        if not 1 <= self.mood_repeat_interval_minutes <= MAX_REPEAT_INTERVAL:
+            raise ValueError(
+                "mood_repeat_interval_minutes must be between 1 and 1440",
+            )
+        try:
+            time.fromisoformat(self.mood_reminder_time)
+        except ValueError as error:
+            raise ValueError("mood_reminder_time must use HH:MM:SS") from error
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize user data."""
@@ -161,6 +178,14 @@ class UserData:
             "mood_history": self.mood_history,
             "mood_today": self.mood_today,
             "mood_note": self.mood_note,
+            "mood_reminder_time": self.mood_reminder_time,
+            "mood_repeat_count": self.mood_repeat_count,
+            "mood_repeat_interval_minutes": self.mood_repeat_interval_minutes,
+            "pending_mood_reminder": (
+                None
+                if self.pending_mood_reminder is None
+                else self.pending_mood_reminder.to_dict()
+            ),
         }
 
     @classmethod
@@ -186,6 +211,12 @@ class UserData:
             _date_string(day): _mood(mood)
             for day, mood in _mapping(value, "mood_history").items()
         }
+        raw_pending_mood = value.get("pending_mood_reminder")
+        pending_mood = (
+            None
+            if raw_pending_mood in (None, {})
+            else PendingReminder.from_dict(_dict(raw_pending_mood))
+        )
         return cls(
             habits=habits,
             completions=completions,
@@ -193,6 +224,14 @@ class UserData:
             mood_history=mood_history,
             mood_today=_mood(value.get("mood_today", "Not Set")),
             mood_note=_string(value, "mood_note", ""),
+            mood_reminder_time=_string(value, "mood_reminder_time", "20:00:00"),
+            mood_repeat_count=_integer(value, "mood_repeat_count", 0),
+            mood_repeat_interval_minutes=_integer(
+                value,
+                "mood_repeat_interval_minutes",
+                60,
+            ),
+            pending_mood_reminder=pending_mood,
         )
 
 

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -10,11 +10,13 @@ from typing import TYPE_CHECKING, Any, Final, Self
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-SCHEMA_VERSION: Final[int] = 1
+SCHEMA_VERSION: Final[int] = 2
 MIN_SCHEMA_VERSION: Final[int] = 1
 MAX_NAME_LENGTH: Final[int] = 255
+MAX_TEMPLATE_LENGTH: Final[int] = 255
 MAX_REPEAT_COUNT: Final[int] = 100
 MAX_REPEAT_INTERVAL: Final[int] = 1440
+MAX_DURATION_MINUTES: Final[int] = 1440
 MAX_DAYS_PER_WEEK: Final[int] = 7
 MAX_STREAK_DAYS: Final[int] = 366
 MOOD_OPTIONS: Final[tuple[str, ...]] = (
@@ -50,6 +52,25 @@ class HabitType(StrEnum):
     COUNTABLE = "countable"
 
 
+class CompletionMode(StrEnum):
+    """How a habit slot decides it is complete for the day."""
+
+    MANUAL = "manual"
+    INSTANT = "instant"
+    CONTINUOUS = "continuous"
+    SUMMED = "summed"
+
+    @property
+    def is_event_driven(self) -> bool:
+        """Return whether the mode evaluates a template."""
+        return self is not CompletionMode.MANUAL
+
+    @property
+    def is_duration_based(self) -> bool:
+        """Return whether the mode accumulates truthy time before completing."""
+        return self in {CompletionMode.CONTINUOUS, CompletionMode.SUMMED}
+
+
 @dataclass(slots=True)
 class HabitConfig:
     """Persistent configuration for one stable numbered habit slot."""
@@ -66,6 +87,9 @@ class HabitConfig:
     icon_active: str = "mdi:counter"
     icon_off: str = "mdi:circle-outline"
     icon_zero: str = "mdi:counter"
+    completion_mode: CompletionMode = CompletionMode.MANUAL
+    completion_template: str = ""
+    completion_duration_minutes: int = 30
 
     def __post_init__(self) -> None:
         """Reject malformed persisted or MQTT-provided configuration."""
@@ -83,6 +107,25 @@ class HabitConfig:
             time.fromisoformat(self.reminder_time)
         except ValueError as error:
             raise ValueError("reminder_time must use HH:MM:SS") from error
+        self._validate_completion()
+
+    def _validate_completion(self) -> None:
+        """Reject inconsistent event-driven completion settings."""
+        if len(self.completion_template) > MAX_TEMPLATE_LENGTH:
+            # Home Assistant states cap at 255 characters, so a longer template
+            # could never round-trip through the text entity.
+            raise ValueError("completion_template is too long")
+        if not 1 <= self.completion_duration_minutes <= MAX_DURATION_MINUTES:
+            raise ValueError(
+                "completion_duration_minutes must be between 1 and 1440",
+            )
+        if self.completion_mode.is_event_driven and not self.completion_template.strip():
+            raise ValueError("completion_template is required for event-driven modes")
+        if (
+            self.completion_mode.is_duration_based
+            and self.habit_type is not HabitType.BINARY
+        ):
+            raise ValueError("duration completion modes require a binary habit")
 
     @property
     def configured(self) -> bool:
@@ -117,6 +160,15 @@ class HabitConfig:
             icon_active=_string(value, "icon_active", "mdi:counter"),
             icon_off=_string(value, "icon_off", "mdi:circle-outline"),
             icon_zero=_string(value, "icon_zero", "mdi:counter"),
+            completion_mode=CompletionMode(
+                _string(value, "completion_mode", CompletionMode.MANUAL),
+            ),
+            completion_template=_string(value, "completion_template", ""),
+            completion_duration_minutes=_integer(
+                value,
+                "completion_duration_minutes",
+                30,
+            ),
         )
 
 
@@ -155,12 +207,54 @@ class PendingReminder:
 
 
 @dataclass(slots=True)
+class TemplateProgress:
+    """Durable truthy-time accounting for one event-driven habit slot."""
+
+    day: str
+    accumulated_seconds: int = 0
+    truthy_since: str | None = None
+    suppressed_day: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject malformed progress state."""
+        date.fromisoformat(self.day)
+        if self.accumulated_seconds < 0:
+            raise ValueError("accumulated_seconds cannot be negative")
+        if self.truthy_since is not None:
+            datetime.fromisoformat(self.truthy_since)
+        if self.suppressed_day is not None:
+            date.fromisoformat(self.suppressed_day)
+
+    @property
+    def is_truthy(self) -> bool:
+        """Return whether the template was truthy at the last observation."""
+        return self.truthy_since is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize progress state."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse and validate progress state."""
+        progress = cls(
+            day=_string(value, "day"),
+            accumulated_seconds=_integer(value, "accumulated_seconds", 0),
+            truthy_since=_optional_string(value, "truthy_since"),
+            suppressed_day=_optional_string(value, "suppressed_day"),
+        )
+        progress.__post_init__()
+        return progress
+
+
+@dataclass(slots=True)
 class UserData:
     """All disk-backed state for one configured user."""
 
     habits: dict[int, HabitConfig] = field(default_factory=dict)
     completions: dict[int, dict[str, int]] = field(default_factory=dict)
     pending_reminders: dict[int, PendingReminder] = field(default_factory=dict)
+    template_progress: dict[int, TemplateProgress] = field(default_factory=dict)
     mood_history: dict[str, str] = field(default_factory=dict)
     mood_today: str = "Not Set"
     mood_note: str = ""
@@ -196,6 +290,10 @@ class UserData:
                 str(slot): pending.to_dict()
                 for slot, pending in self.pending_reminders.items()
             },
+            "template_progress": {
+                str(slot): progress.to_dict()
+                for slot, progress in self.template_progress.items()
+            },
             "mood_history": self.mood_history,
             "mood_today": self.mood_today,
             "mood_note": self.mood_note,
@@ -229,6 +327,10 @@ class UserData:
             int(slot): PendingReminder.from_dict(_dict(item))
             for slot, item in _mapping(value, "pending_reminders").items()
         }
+        template_progress = {
+            int(slot): TemplateProgress.from_dict(_dict(item))
+            for slot, item in _mapping(value, "template_progress").items()
+        }
         mood_history = {
             _date_string(day): _mood(mood)
             for day, mood in _mapping(value, "mood_history").items()
@@ -243,6 +345,7 @@ class UserData:
             habits=habits,
             completions=completions,
             pending_reminders=pending_reminders,
+            template_progress=template_progress,
             mood_history=mood_history,
             mood_today=_mood(value.get("mood_today", "Not Set")),
             mood_note=_string(value, "mood_note", ""),
@@ -262,10 +365,21 @@ class UserData:
         )
 
 
+def _migrate_1_to_2(value: dict[str, Any]) -> dict[str, Any]:
+    """Add event-driven completion fields.
+
+    Purely additive: every new field is defaulted by ``HabitConfig.from_dict``
+    and ``UserData.from_dict``, so a v1 payload needs no rewriting.
+    """
+    return value
+
+
 # Upgrade steps keyed by source version; entry N migrates a payload from
 # version N to version N+1. Register a step in the same change that bumps
 # SCHEMA_VERSION.
-SCHEMA_MIGRATIONS: Final[dict[int, Callable[[dict[str, Any]], dict[str, Any]]]] = {}
+SCHEMA_MIGRATIONS: Final[dict[int, Callable[[dict[str, Any]], dict[str, Any]]]] = {
+    1: _migrate_1_to_2,
+}
 
 
 def migrate_store_payload(
@@ -399,6 +513,7 @@ def normalize_spare_slot(data: UserData) -> tuple[int | None, tuple[int, ...]]:
         del data.habits[slot]
         data.completions.pop(slot, None)
         data.pending_reminders.pop(slot, None)
+        data.template_progress.pop(slot, None)
     return added_spare, retired
 
 
@@ -459,6 +574,15 @@ def _string(
     item = value.get(key, default)
     if not isinstance(item, str):
         raise TypeError(f"{key} must be a string")
+    return item
+
+
+def _optional_string(value: dict[str, Any], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str):
+        raise TypeError(f"{key} must be a string or null")
     return item
 
 

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -157,14 +157,12 @@ class StoreData:
     """Top-level versioned persistence schema."""
 
     users: dict[str, UserData]
-    bootstrap_complete: bool = False
     schema_version: int = SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the complete store."""
         return {
             "schema_version": self.schema_version,
-            "bootstrap_complete": self.bootstrap_complete,
             "users": {user: data.to_dict() for user, data in self.users.items()},
         }
 
@@ -187,11 +185,6 @@ class StoreData:
         }
         return cls(
             users=users,
-            bootstrap_complete=_boolean(
-                value,
-                "bootstrap_complete",
-                default=False,
-            ),
             schema_version=version,
         )
 

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -1,0 +1,363 @@
+"""Validated domain models and streak calculations for habit tracking."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import date, time, timedelta
+from enum import StrEnum
+from typing import Any, Final, Self
+
+SCHEMA_VERSION: Final[int] = 1
+MAX_NAME_LENGTH: Final[int] = 255
+MAX_REPEAT_COUNT: Final[int] = 100
+MAX_REPEAT_INTERVAL: Final[int] = 1440
+MAX_DAYS_PER_WEEK: Final[int] = 7
+MAX_STREAK_DAYS: Final[int] = 366
+MOOD_OPTIONS: Final[tuple[str, ...]] = (
+    "Not Set",
+    "Very Low",
+    "Low",
+    "Okay",
+    "Good",
+    "Great",
+)
+
+
+class HabitType(StrEnum):
+    """Supported habit completion models."""
+
+    BINARY = "binary"
+    COUNTABLE = "countable"
+
+
+@dataclass(slots=True)
+class HabitConfig:
+    """Persistent configuration for one stable numbered habit slot."""
+
+    slot: int
+    name: str = ""
+    habit_type: HabitType = HabitType.BINARY
+    reminder_time: str = "09:00:00"
+    repeat_count: int = 0
+    repeat_interval_minutes: int = 60
+    streak_min_days_per_week: int = 7
+    ai_enabled: bool = False
+    icon_on: str = "mdi:check-circle"
+    icon_active: str = "mdi:counter"
+    icon_off: str = "mdi:circle-outline"
+    icon_zero: str = "mdi:counter"
+
+    def __post_init__(self) -> None:
+        """Reject malformed persisted or MQTT-provided configuration."""
+        if self.slot < 1:
+            raise ValueError("slot must be positive")
+        if len(self.name) > MAX_NAME_LENGTH:
+            raise ValueError("habit name is too long")
+        if not 0 <= self.repeat_count <= MAX_REPEAT_COUNT:
+            raise ValueError("repeat_count must be between 0 and 100")
+        if not 1 <= self.repeat_interval_minutes <= MAX_REPEAT_INTERVAL:
+            raise ValueError("repeat_interval_minutes must be between 1 and 1440")
+        if not 1 <= self.streak_min_days_per_week <= MAX_DAYS_PER_WEEK:
+            raise ValueError("streak_min_days_per_week must be between 1 and 7")
+        try:
+            time.fromisoformat(self.reminder_time)
+        except ValueError as error:
+            raise ValueError("reminder_time must use HH:MM:SS") from error
+
+    @property
+    def configured(self) -> bool:
+        """Return whether the slot has a user-facing name."""
+        return bool(self.name.strip())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the configuration to JSON-compatible values."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse and validate a configuration mapping."""
+        return cls(
+            slot=_integer(value, "slot"),
+            name=_string(value, "name", ""),
+            habit_type=HabitType(_string(value, "habit_type", HabitType.BINARY)),
+            reminder_time=_string(value, "reminder_time", "09:00:00"),
+            repeat_count=_integer(value, "repeat_count", 0),
+            repeat_interval_minutes=_integer(
+                value,
+                "repeat_interval_minutes",
+                60,
+            ),
+            streak_min_days_per_week=_integer(
+                value,
+                "streak_min_days_per_week",
+                7,
+            ),
+            ai_enabled=_boolean(value, "ai_enabled", default=False),
+            icon_on=_string(value, "icon_on", "mdi:check-circle"),
+            icon_active=_string(value, "icon_active", "mdi:counter"),
+            icon_off=_string(value, "icon_off", "mdi:circle-outline"),
+            icon_zero=_string(value, "icon_zero", "mdi:counter"),
+        )
+
+
+@dataclass(slots=True)
+class UserData:
+    """All disk-backed state for one configured user."""
+
+    habits: dict[int, HabitConfig] = field(default_factory=dict)
+    completions: dict[int, dict[str, int]] = field(default_factory=dict)
+    mood_history: dict[str, str] = field(default_factory=dict)
+    mood_today: str = "Not Set"
+    mood_note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize user data."""
+        return {
+            "habits": {
+                str(slot): config.to_dict() for slot, config in self.habits.items()
+            },
+            "completions": {
+                str(slot): values for slot, values in self.completions.items()
+            },
+            "mood_history": self.mood_history,
+            "mood_today": self.mood_today,
+            "mood_note": self.mood_note,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse and validate persisted user data."""
+        raw_habits = _mapping(value, "habits")
+        raw_completions = _mapping(value, "completions")
+        habits = {
+            int(slot): HabitConfig.from_dict(_dict(item))
+            for slot, item in raw_habits.items()
+        }
+        completions: dict[int, dict[str, int]] = {}
+        for slot, entries in raw_completions.items():
+            completions[int(slot)] = {
+                _date_string(day): _nonnegative_integer(count)
+                for day, count in _dict(entries).items()
+            }
+        mood_history = {
+            _date_string(day): _mood(mood)
+            for day, mood in _mapping(value, "mood_history").items()
+        }
+        return cls(
+            habits=habits,
+            completions=completions,
+            mood_history=mood_history,
+            mood_today=_mood(value.get("mood_today", "Not Set")),
+            mood_note=_string(value, "mood_note", ""),
+        )
+
+
+@dataclass(slots=True)
+class StoreData:
+    """Top-level versioned persistence schema."""
+
+    users: dict[str, UserData]
+    bootstrap_complete: bool = False
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the complete store."""
+        return {
+            "schema_version": self.schema_version,
+            "bootstrap_complete": self.bootstrap_complete,
+            "users": {user: data.to_dict() for user, data in self.users.items()},
+        }
+
+    @classmethod
+    def empty(cls, users: tuple[str, ...]) -> Self:
+        """Create an empty store with one spare slot per user."""
+        return cls(
+            users={user: UserData(habits={1: HabitConfig(slot=1)}) for user in users},
+        )
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse the current schema, rejecting unsupported versions."""
+        version = _integer(value, "schema_version")
+        if version != SCHEMA_VERSION:
+            raise ValueError(f"unsupported schema version: {version}")
+        users = {
+            str(user): UserData.from_dict(_dict(data))
+            for user, data in _mapping(value, "users").items()
+        }
+        return cls(
+            users=users,
+            bootstrap_complete=_boolean(
+                value,
+                "bootstrap_complete",
+                default=False,
+            ),
+            schema_version=version,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StreakStats:
+    """Derived habit history metrics."""
+
+    streak: int
+    days_since_completion: int
+    completion_rate_28_days: float
+
+
+def calculate_streak(
+    completions: dict[str, int],
+    *,
+    today: date,
+    min_days_per_week: int,
+) -> StreakStats:
+    """Calculate strict daily or weekly-qualified calendar-day streaks."""
+    completed = {
+        date.fromisoformat(day) for day, count in completions.items() if count > 0
+    }
+    anchor = today if today in completed else today - timedelta(days=1)
+    streak = (
+        _strict_daily_streak(completed, anchor)
+        if min_days_per_week == MAX_DAYS_PER_WEEK
+        else _weekly_streak(
+            completed,
+            anchor=anchor,
+            today=today,
+            min_days_per_week=min_days_per_week,
+        )
+    )
+    latest = max(completed, default=None)
+    days_since = -1 if latest is None else (today - latest).days
+    completed_28 = sum(
+        today - timedelta(days=27) <= completed_day <= today
+        for completed_day in completed
+    )
+    return StreakStats(streak, days_since, round(completed_28 / 28 * 100, 1))
+
+
+def calculate_mood_streak(mood_history: dict[str, str], *, today: date) -> int:
+    """Count consecutive completed mood entries ending yesterday."""
+    streak = 0
+    checked = today - timedelta(days=1)
+    while mood_history.get(checked.isoformat()) in MOOD_OPTIONS[1:]:
+        streak += 1
+        checked -= timedelta(days=1)
+    return streak
+
+
+def normalize_spare_slot(data: UserData) -> tuple[int | None, tuple[int, ...]]:
+    """Keep exactly the lowest stable unconfigured slot.
+
+    Retired slots must lose their completion history. Otherwise a later habit can
+    reuse the same numeric slot and incorrectly inherit the deleted habit's streak.
+    """
+    empty_slots = sorted(
+        slot for slot, habit in data.habits.items() if not habit.configured
+    )
+    added_spare: int | None = None
+    if empty_slots:
+        spare_slot = empty_slots[0]
+    else:
+        spare_slot = 1
+        while spare_slot in data.habits:
+            spare_slot += 1
+        data.habits[spare_slot] = HabitConfig(slot=spare_slot)
+        added_spare = spare_slot
+    retired = tuple(slot for slot in empty_slots if slot != spare_slot)
+    for slot in retired:
+        del data.habits[slot]
+        data.completions.pop(slot, None)
+    return added_spare, retired
+
+
+def _week_start(value: date) -> date:
+    return value - timedelta(days=value.weekday())
+
+
+def _strict_daily_streak(completed: set[date], anchor: date) -> int:
+    if anchor not in completed:
+        return 0
+    streak = 0
+    checked = anchor
+    while checked in completed and streak < MAX_STREAK_DAYS:
+        streak += 1
+        checked -= timedelta(days=1)
+    return streak
+
+
+def _weekly_streak(
+    completed: set[date],
+    *,
+    anchor: date,
+    today: date,
+    min_days_per_week: int,
+) -> int:
+    if anchor not in completed or (today - anchor).days > 1:
+        return 0
+    anchor_week = _week_start(anchor)
+    streak = (anchor - anchor_week).days + 1
+    checked_week = anchor_week - timedelta(days=7)
+    for _ in range(52):
+        completed_days = sum(
+            checked_week <= completed_day <= checked_week + timedelta(days=6)
+            for completed_day in completed
+        )
+        if completed_days < min_days_per_week:
+            break
+        streak += 7
+        checked_week -= timedelta(days=7)
+    return streak
+
+
+def _dict(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError("expected an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _mapping(value: dict[str, Any], key: str) -> dict[str, Any]:
+    return _dict(value.get(key, {}))
+
+
+def _string(
+    value: dict[str, Any],
+    key: str,
+    default: str | HabitType | None = None,
+) -> str:
+    item = value.get(key, default)
+    if not isinstance(item, str):
+        raise TypeError(f"{key} must be a string")
+    return item
+
+
+def _integer(value: dict[str, Any], key: str, default: int | None = None) -> int:
+    item = value.get(key, default)
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise TypeError(f"{key} must be an integer")
+    return item
+
+
+def _nonnegative_integer(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("completion count must be a non-negative integer")
+    return value
+
+
+def _boolean(value: dict[str, Any], key: str, *, default: bool) -> bool:
+    item = value.get(key, default)
+    if not isinstance(item, bool):
+        raise TypeError(f"{key} must be a boolean")
+    return item
+
+
+def _date_string(value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError("date key must be a string")
+    date.fromisoformat(value)
+    return value
+
+
+def _mood(value: object) -> str:
+    if not isinstance(value, str) or value not in MOOD_OPTIONS:
+        raise ValueError("invalid mood")
+    return value

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from datetime import date, time, timedelta
+from datetime import date, datetime, time, timedelta
 from enum import StrEnum
 from typing import Any, Final, Self
 
@@ -101,11 +101,46 @@ class HabitConfig:
 
 
 @dataclass(slots=True)
+class PendingReminder:
+    """Durable next-fire metadata for one habit slot."""
+
+    fire_at: str
+    next_index: int
+    final_index: int
+
+    def __post_init__(self) -> None:
+        """Reject malformed reminder state."""
+        datetime.fromisoformat(self.fire_at)
+        if self.next_index < 1:
+            raise ValueError("next_index must be positive")
+        if self.final_index < 1:
+            raise ValueError("final_index must be positive")
+        if self.next_index > self.final_index:
+            raise ValueError("next_index cannot exceed final_index")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize pending reminder state."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse and validate pending reminder state."""
+        pending = cls(
+            fire_at=_string(value, "fire_at"),
+            next_index=_integer(value, "next_index"),
+            final_index=_integer(value, "final_index"),
+        )
+        pending.__post_init__()
+        return pending
+
+
+@dataclass(slots=True)
 class UserData:
     """All disk-backed state for one configured user."""
 
     habits: dict[int, HabitConfig] = field(default_factory=dict)
     completions: dict[int, dict[str, int]] = field(default_factory=dict)
+    pending_reminders: dict[int, PendingReminder] = field(default_factory=dict)
     mood_history: dict[str, str] = field(default_factory=dict)
     mood_today: str = "Not Set"
     mood_note: str = ""
@@ -118,6 +153,10 @@ class UserData:
             },
             "completions": {
                 str(slot): values for slot, values in self.completions.items()
+            },
+            "pending_reminders": {
+                str(slot): pending.to_dict()
+                for slot, pending in self.pending_reminders.items()
             },
             "mood_history": self.mood_history,
             "mood_today": self.mood_today,
@@ -139,6 +178,10 @@ class UserData:
                 _date_string(day): _nonnegative_integer(count)
                 for day, count in _dict(entries).items()
             }
+        pending_reminders = {
+            int(slot): PendingReminder.from_dict(_dict(item))
+            for slot, item in _mapping(value, "pending_reminders").items()
+        }
         mood_history = {
             _date_string(day): _mood(mood)
             for day, mood in _mapping(value, "mood_history").items()
@@ -146,6 +189,7 @@ class UserData:
         return cls(
             habits=habits,
             completions=completions,
+            pending_reminders=pending_reminders,
             mood_history=mood_history,
             mood_today=_mood(value.get("mood_today", "Not Set")),
             mood_note=_string(value, "mood_note", ""),
@@ -260,6 +304,7 @@ def normalize_spare_slot(data: UserData) -> tuple[int | None, tuple[int, ...]]:
     for slot in retired:
         del data.habits[slot]
         data.completions.pop(slot, None)
+        data.pending_reminders.pop(slot, None)
     return added_spare, retired
 
 

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -1,0 +1,372 @@
+"""Raw paho MQTT transport and current Home Assistant discovery definitions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import paho.mqtt.client as paho
+from paho.mqtt.enums import CallbackAPIVersion
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from paho.mqtt.properties import Properties
+    from paho.mqtt.reasoncodes import ReasonCode
+
+    from .models import HabitConfig
+
+
+@dataclass(frozen=True, slots=True)
+class MqttSettings:
+    """MQTT connection and topic settings."""
+
+    host: str
+    port: int
+    username: str | None
+    password: str | None
+    discovery_prefix: str
+    base_topic: str
+    qos: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class EntitySpec:
+    """One MQTT discovery entity."""
+
+    component: str
+    key: str
+    name: str
+    extra: dict[str, object]
+    configurable: bool = True
+
+
+class HabitMqtt:
+    """Publish retained discovery/state and safely forward commands."""
+
+    def __init__(
+        self,
+        settings: MqttSettings,
+        *,
+        on_command: Callable[[str, str], None],
+        dispatch: Callable[[Callable[..., None], str, str], None],
+        on_connect: Callable[[], None],
+        log: Callable[..., None],
+    ) -> None:
+        self.settings = settings
+        self._on_command = on_command
+        self._dispatch = dispatch
+        self._connected_callback = on_connect
+        self._log = log
+        self.client = paho.Client(
+            callback_api_version=CallbackAPIVersion.VERSION2,
+            client_id="appdaemon-habit-tracker",
+        )
+        if settings.username:
+            self.client.username_pw_set(settings.username, settings.password)
+        self.client.on_connect = self._handle_connect
+        self.client.on_message = self._handle_message
+        self.client.will_set(
+            self.topic("availability"),
+            "offline",
+            qos=settings.qos,
+            retain=True,
+        )
+
+    def connect(self) -> None:
+        """Connect and start paho's network thread."""
+        self.client.connect(self.settings.host, self.settings.port, keepalive=60)
+        self.client.loop_start()
+
+    def disconnect(self) -> None:
+        """Publish a clean shutdown and stop paho."""
+        self.publish(self.topic("availability"), "offline")
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    def topic(self, suffix: str) -> str:
+        """Build a topic below the configured base."""
+        return f"{self.settings.base_topic}/{suffix}"
+
+    def publish(self, topic: str, payload: object, *, retain: bool = True) -> None:
+        """Publish JSON or scalar data."""
+        serialized = payload if isinstance(payload, str) else json.dumps(payload)
+        self.client.publish(
+            topic,
+            serialized,
+            qos=self.settings.qos,
+            retain=retain,
+        )
+
+    def publish_slot(self, user: str, config: HabitConfig) -> None:
+        """Publish named discovery and configuration state for one slot."""
+        display = config.name.strip() or "New habit"
+        prefix = f"{user}_habit_{config.slot}"
+        state_prefix = self.topic(f"{user}/{config.slot}")
+        is_binary = str(config.habit_type) == "binary"
+        state_spec = EntitySpec(
+            "switch" if is_binary else "number",
+            "state" if is_binary else "count",
+            display,
+            ({} if is_binary else {"min": 0, "max": 100000, "step": 1, "mode": "box"}),
+            configurable=False,
+        )
+        specs = (
+            EntitySpec("text", "name", f"{display} name", {}),
+            EntitySpec(
+                "select",
+                "type",
+                f"{display} type",
+                {"options": ["binary", "countable"]},
+            ),
+            state_spec,
+            EntitySpec("time", "reminder_time", f"{display} reminder time", {}),
+            EntitySpec(
+                "number",
+                "repeat_count",
+                f"{display} repeat count",
+                {"min": 0, "max": 100, "step": 1, "mode": "box"},
+            ),
+            EntitySpec(
+                "number",
+                "repeat_interval",
+                f"{display} repeat interval",
+                {
+                    "min": 1,
+                    "max": 1440,
+                    "step": 1,
+                    "mode": "box",
+                    "unit_of_measurement": "min",
+                },
+            ),
+            EntitySpec(
+                "number",
+                "streak_min_days",
+                f"{display} minimum days per week",
+                {"min": 1, "max": 7, "step": 1, "mode": "box"},
+            ),
+            EntitySpec("switch", "ai", f"{display} AI reminders", {}),
+            EntitySpec("text", "icon_on", f"{display} completed icon", {}),
+            EntitySpec("text", "icon_active", f"{display} active icon", {}),
+            EntitySpec("text", "icon_off", f"{display} incomplete icon", {}),
+            EntitySpec("text", "icon_zero", f"{display} zero icon", {}),
+            EntitySpec(
+                "sensor",
+                "streak",
+                f"{display} streak",
+                {"unit_of_measurement": "days", "icon": "mdi:fire"},
+                configurable=False,
+            ),
+        )
+        self._retire_opposite_state(user, config.slot, is_binary=is_binary)
+        self._retire_per_slot_test(user, config.slot)
+        for spec in specs:
+            object_id = f"{prefix}_{spec.key}"
+            payload: dict[str, object] = {
+                "name": spec.name,
+                "unique_id": f"appdaemon_{object_id}",
+                "default_entity_id": f"{spec.component}.{object_id}",
+                "availability_topic": self.topic("availability"),
+                "payload_available": "online",
+                "payload_not_available": "offline",
+                "device": self._device(user),
+                "origin": self._origin(),
+                **spec.extra,
+            }
+            if spec.component != "button":
+                payload["state_topic"] = f"{state_prefix}/{spec.key}/state"
+            if spec.component != "sensor":
+                payload["command_topic"] = f"{state_prefix}/{spec.key}/set"
+            if spec.component == "switch":
+                payload.update({"payload_on": "ON", "payload_off": "OFF"})
+            if spec.configurable:
+                payload["entity_category"] = "config"
+            if spec.key in {"name", "state", "count", "streak"}:
+                payload["json_attributes_topic"] = f"{state_prefix}/{spec.key}/attributes"
+            self.publish(self._config_topic(spec.component, object_id), payload)
+        self.publish_config_state(user, config)
+
+    def publish_user_discovery(self, user: str) -> None:
+        """Publish one deterministic test-reminder button per user."""
+        object_id = f"{user}_habit_test_reminder"
+        payload = {
+            "name": "Test habit reminder",
+            "unique_id": f"appdaemon_{object_id}",
+            "default_entity_id": f"button.{object_id}",
+            "command_topic": self.topic(f"{user}/test/set"),
+            "availability_topic": self.topic("availability"),
+            "payload_available": "online",
+            "payload_not_available": "offline",
+            "icon": "mdi:bell-ring-outline",
+            "device": self._device(user),
+            "origin": self._origin(),
+        }
+        self.publish(self._config_topic("button", object_id), payload)
+
+    def publish_config_state(self, user: str, config: HabitConfig) -> None:
+        """Publish all editable values for one slot."""
+        prefix = self.topic(f"{user}/{config.slot}")
+        values: dict[str, object] = {
+            "name": config.name,
+            "type": config.habit_type,
+            "reminder_time": config.reminder_time,
+            "repeat_count": config.repeat_count,
+            "repeat_interval": config.repeat_interval_minutes,
+            "streak_min_days": config.streak_min_days_per_week,
+            "ai": "ON" if config.ai_enabled else "OFF",
+            "icon_on": config.icon_on,
+            "icon_active": config.icon_active,
+            "icon_off": config.icon_off,
+            "icon_zero": config.icon_zero,
+        }
+        for key, value in values.items():
+            self.publish(f"{prefix}/{key}/state", str(value))
+
+    def retire_slot(self, user: str, slot: int) -> None:
+        """Retire every retained discovery config for an unconfigured slot."""
+        for component, key in _slot_entity_keys():
+            self.publish(
+                self._config_topic(component, f"{user}_habit_{slot}_{key}"),
+                "",
+            )
+
+    def publish_mood_discovery(self, users: Iterable[str]) -> None:
+        """Publish mood entities with consistent availability and origin."""
+        for user in users:
+            for spec in (
+                EntitySpec(
+                    "select",
+                    "mood_today",
+                    "Mood today",
+                    {"options": list(_mood_options())},
+                ),
+                EntitySpec("text", "mood_note", "Mood note", {}),
+                EntitySpec(
+                    "sensor",
+                    "mood_streak",
+                    "Mood streak",
+                    {"unit_of_measurement": "days", "icon": "mdi:fire"},
+                    configurable=False,
+                ),
+            ):
+                object_id = f"{user}_{spec.key}"
+                payload: dict[str, object] = {
+                    "name": spec.name,
+                    "unique_id": f"appdaemon_{object_id}",
+                    "default_entity_id": f"{spec.component}.{object_id}",
+                    "state_topic": self.topic(f"{user}/mood/{spec.key}/state"),
+                    "availability_topic": self.topic("availability"),
+                    "payload_available": "online",
+                    "payload_not_available": "offline",
+                    "device": self._device(user),
+                    "origin": self._origin(),
+                    **spec.extra,
+                }
+                if spec.component != "sensor":
+                    payload["command_topic"] = self.topic(
+                        f"{user}/mood/{spec.key}/set",
+                    )
+                if spec.configurable:
+                    payload["entity_category"] = "config"
+                self.publish(self._config_topic(spec.component, object_id), payload)
+
+    def subscribe_commands(self) -> None:
+        """Subscribe to slot, mood, and user test commands."""
+        for topic in ("+/+/+/set", "+/mood/+/set", "+/test/set"):
+            self.client.subscribe(self.topic(topic), qos=self.settings.qos)
+
+    def _handle_connect(
+        self,
+        _client: paho.Client,
+        _userdata: object,
+        _flags: paho.ConnectFlags,
+        reason_code: ReasonCode,
+        _properties: Properties | None,
+    ) -> None:
+        if reason_code.is_failure:
+            self._log("MQTT connection failed: %s", reason_code)
+            return
+        self.subscribe_commands()
+        self.publish(self.topic("availability"), "online")
+        self._dispatch(self._connected_adapter, "", "")
+
+    def _connected_adapter(self, _topic: str, _payload: str) -> None:
+        self._connected_callback()
+
+    def _handle_message(
+        self,
+        _client: paho.Client,
+        _userdata: object,
+        message: paho.MQTTMessage,
+    ) -> None:
+        try:
+            payload = message.payload.decode("utf-8")
+        except UnicodeDecodeError:
+            self._log("Ignoring non-UTF-8 MQTT command on %s", message.topic)
+            return
+        self._dispatch(self._on_command, str(message.topic), payload)
+
+    def _retire_opposite_state(
+        self,
+        user: str,
+        slot: int,
+        *,
+        is_binary: bool,
+    ) -> None:
+        component, key = ("number", "count") if is_binary else ("switch", "state")
+        self.publish(
+            self._config_topic(component, f"{user}_habit_{slot}_{key}"),
+            "",
+        )
+
+    def _retire_per_slot_test(self, user: str, slot: int) -> None:
+        self.publish(
+            self._config_topic("button", f"{user}_habit_{slot}_test"),
+            "",
+        )
+
+    def _config_topic(self, component: str, object_id: str) -> str:
+        return f"{self.settings.discovery_prefix}/{component}/{object_id}/config"
+
+    @staticmethod
+    def _device(user: str) -> dict[str, object]:
+        return {
+            "identifiers": [f"appdaemon_habits_{user}"],
+            "manufacturer": "AppDaemon",
+            "model": "Habit Tracker",
+            "name": f"{user.title()} Habits",
+        }
+
+    @staticmethod
+    def _origin() -> dict[str, str]:
+        return {
+            "name": "AppDaemon Habit Tracker",
+            "sw": "home-assistant-appdaemon",
+        }
+
+
+def _slot_entity_keys() -> tuple[tuple[str, str], ...]:
+    return (
+        ("text", "name"),
+        ("select", "type"),
+        ("switch", "state"),
+        ("number", "count"),
+        ("time", "reminder_time"),
+        ("number", "repeat_count"),
+        ("number", "repeat_interval"),
+        ("number", "streak_min_days"),
+        ("switch", "ai"),
+        ("text", "icon_on"),
+        ("text", "icon_active"),
+        ("text", "icon_off"),
+        ("text", "icon_zero"),
+        ("sensor", "streak"),
+        ("button", "test"),
+    )
+
+
+def _mood_options() -> tuple[str, ...]:
+    from .models import MOOD_OPTIONS  # noqa: PLC0415
+
+    return MOOD_OPTIONS

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -160,7 +160,6 @@ class HabitMqtt:
             ),
         )
         self._retire_opposite_state(user, config.slot, is_binary=is_binary)
-        self._retire_per_slot_test(user, config.slot)
         for spec in specs:
             object_id = f"{prefix}_{spec.key}"
             payload: dict[str, object] = {
@@ -172,10 +171,9 @@ class HabitMqtt:
                 "payload_not_available": "offline",
                 "device": self._device(user),
                 "origin": self._origin(),
+                "state_topic": f"{state_prefix}/{spec.key}/state",
                 **spec.extra,
             }
-            if spec.component != "button":
-                payload["state_topic"] = f"{state_prefix}/{spec.key}/state"
             if spec.component != "sensor":
                 payload["command_topic"] = f"{state_prefix}/{spec.key}/set"
             if spec.component == "switch":
@@ -186,23 +184,6 @@ class HabitMqtt:
                 payload["json_attributes_topic"] = f"{state_prefix}/{spec.key}/attributes"
             self.publish(self._config_topic(spec.component, object_id), payload)
         self.publish_config_state(user, config)
-
-    def publish_user_discovery(self, user: str) -> None:
-        """Publish one deterministic test-reminder button per user."""
-        object_id = f"{user}_habit_test_reminder"
-        payload = {
-            "name": "Test habit reminder",
-            "unique_id": f"appdaemon_{object_id}",
-            "default_entity_id": f"button.{object_id}",
-            "command_topic": self.topic(f"{user}/test/set"),
-            "availability_topic": self.topic("availability"),
-            "payload_available": "online",
-            "payload_not_available": "offline",
-            "icon": "mdi:bell-ring-outline",
-            "device": self._device(user),
-            "origin": self._origin(),
-        }
-        self.publish(self._config_topic("button", object_id), payload)
 
     def publish_config_state(self, user: str, config: HabitConfig) -> None:
         """Publish all editable values for one slot."""
@@ -272,8 +253,8 @@ class HabitMqtt:
                 self.publish(self._config_topic(spec.component, object_id), payload)
 
     def subscribe_commands(self) -> None:
-        """Subscribe to slot, mood, and user test commands."""
-        for topic in ("+/+/+/set", "+/mood/+/set", "+/test/set"):
+        """Subscribe to slot and mood commands."""
+        for topic in ("+/+/+/set", "+/mood/+/set"):
             self.client.subscribe(self.topic(topic), qos=self.settings.qos)
 
     def _handle_connect(
@@ -320,12 +301,6 @@ class HabitMqtt:
             "",
         )
 
-    def _retire_per_slot_test(self, user: str, slot: int) -> None:
-        self.publish(
-            self._config_topic("button", f"{user}_habit_{slot}_test"),
-            "",
-        )
-
     def _config_topic(self, component: str, object_id: str) -> str:
         return f"{self.settings.discovery_prefix}/{component}/{object_id}/config"
 
@@ -362,7 +337,6 @@ def _slot_entity_keys() -> tuple[tuple[str, str], ...]:
         ("text", "icon_off"),
         ("text", "icon_zero"),
         ("sensor", "streak"),
-        ("button", "test"),
     )
 
 

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -154,6 +154,30 @@ class HabitMqtt:
                 {"min": 1, "max": 7, "step": 1, "mode": "box"},
             ),
             EntitySpec("switch", "ai", f"{display} AI reminders", {}),
+            EntitySpec(
+                "select",
+                "completion_mode",
+                f"{display} completion mode",
+                {"options": list(_completion_modes())},
+            ),
+            EntitySpec(
+                "text",
+                "completion_template",
+                f"{display} completion template",
+                {"max": _max_template_length(), "icon": "mdi:code-braces"},
+            ),
+            EntitySpec(
+                "number",
+                "completion_duration",
+                f"{display} completion duration",
+                {
+                    "min": 1,
+                    "max": 1440,
+                    "step": 1,
+                    "mode": "box",
+                    "unit_of_measurement": "min",
+                },
+            ),
             EntitySpec("text", "icon_on", f"{display} completed icon", {}),
             EntitySpec("text", "icon_active", f"{display} active icon", {}),
             EntitySpec("text", "icon_off", f"{display} incomplete icon", {}),
@@ -207,6 +231,9 @@ class HabitMqtt:
             "icon_active": config.icon_active,
             "icon_off": config.icon_off,
             "icon_zero": config.icon_zero,
+            "completion_mode": config.completion_mode,
+            "completion_template": config.completion_template,
+            "completion_duration": config.completion_duration_minutes,
         }
         for key, value in values.items():
             self.publish(f"{prefix}/{key}/state", str(value))
@@ -383,6 +410,9 @@ def _slot_entity_keys() -> tuple[tuple[str, str], ...]:
         ("text", "icon_active"),
         ("text", "icon_off"),
         ("text", "icon_zero"),
+        ("select", "completion_mode"),
+        ("text", "completion_template"),
+        ("number", "completion_duration"),
         ("sensor", "streak"),
     )
 
@@ -391,3 +421,15 @@ def _mood_options() -> tuple[str, ...]:
     from .models import MOOD_OPTIONS  # noqa: PLC0415
 
     return MOOD_OPTIONS
+
+
+def _completion_modes() -> tuple[str, ...]:
+    from .models import CompletionMode  # noqa: PLC0415
+
+    return tuple(str(mode) for mode in CompletionMode)
+
+
+def _max_template_length() -> int:
+    from .models import MAX_TEMPLATE_LENGTH  # noqa: PLC0415
+
+    return MAX_TEMPLATE_LENGTH

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -244,6 +244,12 @@ class HabitMqtt:
                     {},
                 ),
                 EntitySpec(
+                    "switch",
+                    "mood_reminders",
+                    "Mood reminders",
+                    {},
+                ),
+                EntitySpec(
                     "datetime",
                     "mood_next_reminder",
                     "Mood next reminder",
@@ -286,6 +292,8 @@ class HabitMqtt:
                     payload["command_topic"] = self.topic(
                         f"{user}/mood/{spec.key}/set",
                     )
+                if spec.component == "switch":
+                    payload.update({"payload_on": "ON", "payload_off": "OFF"})
                 if spec.configurable:
                     payload["entity_category"] = "config"
                 self.publish(self._config_topic(spec.component, object_id), payload)

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 import paho.mqtt.client as paho
 from paho.mqtt.enums import CallbackAPIVersion
 
+from .models import MAX_TEMPLATE_LENGTH, MOOD_OPTIONS, CompletionMode
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
@@ -158,13 +160,13 @@ class HabitMqtt:
                 "select",
                 "completion_mode",
                 f"{display} completion mode",
-                {"options": list(_completion_modes())},
+                {"options": [str(mode) for mode in CompletionMode]},
             ),
             EntitySpec(
                 "text",
                 "completion_template",
                 f"{display} completion template",
-                {"max": _max_template_length(), "icon": "mdi:code-braces"},
+                {"max": MAX_TEMPLATE_LENGTH, "icon": "mdi:code-braces"},
             ),
             EntitySpec(
                 "number",
@@ -254,7 +256,7 @@ class HabitMqtt:
                     "select",
                     "mood_today",
                     "Mood today",
-                    {"options": list(_mood_options())},
+                    {"options": list(MOOD_OPTIONS)},
                 ),
                 EntitySpec("text", "mood_note", "Mood note", {}),
                 EntitySpec(
@@ -327,8 +329,7 @@ class HabitMqtt:
 
     def subscribe_commands(self) -> None:
         """Subscribe to slot and mood commands."""
-        for topic in ("+/+/+/set", "+/mood/+/set"):
-            self.client.subscribe(self.topic(topic), qos=self.settings.qos)
+        self.client.subscribe(self.topic("+/+/+/set"), qos=self.settings.qos)
 
     def _handle_connect(
         self,
@@ -415,21 +416,3 @@ def _slot_entity_keys() -> tuple[tuple[str, str], ...]:
         ("number", "completion_duration"),
         ("sensor", "streak"),
     )
-
-
-def _mood_options() -> tuple[str, ...]:
-    from .models import MOOD_OPTIONS  # noqa: PLC0415
-
-    return MOOD_OPTIONS
-
-
-def _completion_modes() -> tuple[str, ...]:
-    from .models import CompletionMode  # noqa: PLC0415
-
-    return tuple(str(mode) for mode in CompletionMode)
-
-
-def _max_template_length() -> int:
-    from .models import MAX_TEMPLATE_LENGTH  # noqa: PLC0415
-
-    return MAX_TEMPLATE_LENGTH

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -237,6 +237,37 @@ class HabitMqtt:
                     {"unit_of_measurement": "days", "icon": "mdi:fire"},
                     configurable=False,
                 ),
+                EntitySpec(
+                    "time",
+                    "mood_reminder_time",
+                    "Mood reminder time",
+                    {},
+                ),
+                EntitySpec(
+                    "datetime",
+                    "mood_next_reminder",
+                    "Mood next reminder",
+                    {"icon": "mdi:bell-ring-outline"},
+                    configurable=False,
+                ),
+                EntitySpec(
+                    "number",
+                    "mood_repeat_count",
+                    "Mood repeat count",
+                    {"min": 0, "max": 100, "step": 1, "mode": "box"},
+                ),
+                EntitySpec(
+                    "number",
+                    "mood_repeat_interval",
+                    "Mood repeat interval",
+                    {
+                        "min": 1,
+                        "max": 1440,
+                        "step": 1,
+                        "mode": "box",
+                        "unit_of_measurement": "min",
+                    },
+                ),
             ):
                 object_id = f"{user}_{spec.key}"
                 payload: dict[str, object] = {

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -123,6 +123,13 @@ class HabitMqtt:
             state_spec,
             EntitySpec("time", "reminder_time", f"{display} reminder time", {}),
             EntitySpec(
+                "datetime",
+                "next_reminder",
+                f"{display} next reminder",
+                {"icon": "mdi:bell-ring-outline"},
+                configurable=False,
+            ),
+            EntitySpec(
                 "number",
                 "repeat_count",
                 f"{display} repeat count",
@@ -328,6 +335,7 @@ def _slot_entity_keys() -> tuple[tuple[str, str], ...]:
         ("switch", "state"),
         ("number", "count"),
         ("time", "reminder_time"),
+        ("datetime", "next_reminder"),
         ("number", "repeat_count"),
         ("number", "repeat_interval"),
         ("number", "streak_min_days"),

--- a/apps/habit/reminders.py
+++ b/apps/habit/reminders.py
@@ -13,7 +13,7 @@ class Scheduler(Protocol):
         """Register a delayed callback."""
         ...
 
-    def cancel_timer(self, handle: str) -> bool:
+    def cancel_timer(self, handle: str, *, silent: bool = False) -> bool:
         """Cancel a timer."""
         ...
 
@@ -76,6 +76,14 @@ class ReminderManager:
         """Cancel the pending mood timer for a user."""
         self._cancel_handle(self._timers.pop((user, "mood"), None))
 
+    def release(self, user: str, slot: int) -> None:
+        """Drop a habit timer handle after it has already fired."""
+        self._timers.pop((user, self._habit_key(slot)), None)
+
+    def release_mood(self, user: str) -> None:
+        """Drop a mood timer handle after it has already fired."""
+        self._timers.pop((user, "mood"), None)
+
     def remove(self, user: str, slot: int) -> None:
         """Remove schedules for a retired slot."""
         self.cancel(user, slot)
@@ -110,7 +118,7 @@ class ReminderManager:
 
     def _cancel_handle(self, handle: str | None) -> None:
         if handle is not None:
-            self._scheduler.cancel_timer(handle)
+            self._scheduler.cancel_timer(handle, silent=True)
 
     @staticmethod
     def _habit_key(slot: int) -> str:

--- a/apps/habit/reminders.py
+++ b/apps/habit/reminders.py
@@ -19,12 +19,12 @@ class Scheduler(Protocol):
 
 
 class ReminderManager:
-    """Manage one cancellable absolute-time timer per habit slot."""
+    """Manage one cancellable absolute-time timer per habit slot or mood."""
 
     def __init__(self, scheduler: Scheduler, callback: Any) -> None:
         self._scheduler = scheduler
         self._callback = callback
-        self._timers: dict[tuple[str, int], str] = {}
+        self._timers: dict[tuple[str, str], str] = {}
 
     def schedule_at(
         self,
@@ -37,20 +37,44 @@ class ReminderManager:
         now: datetime,
     ) -> None:
         """Replace the pending timer for a habit with an absolute fire time."""
-        self.cancel(user, slot)
-        delay = max(0, (fire_at - now).total_seconds())
-        self._timers[(user, slot)] = self._scheduler.run_in(
-            self._callback,
-            delay,
-            user=user,
-            slot=slot,
+        self._schedule(
+            user,
+            self._habit_key(slot),
+            fire_at=fire_at,
             reminder_index=reminder_index,
             final_index=final_index,
+            now=now,
+            kind="habit",
+            slot=slot,
+        )
+
+    def schedule_mood(
+        self,
+        user: str,
+        *,
+        fire_at: datetime,
+        reminder_index: int,
+        final_index: int,
+        now: datetime,
+    ) -> None:
+        """Replace the pending mood timer with an absolute fire time."""
+        self._schedule(
+            user,
+            "mood",
+            fire_at=fire_at,
+            reminder_index=reminder_index,
+            final_index=final_index,
+            now=now,
+            kind="mood",
         )
 
     def cancel(self, user: str, slot: int) -> None:
-        """Cancel the pending timer for a slot."""
-        self._cancel_handle(self._timers.pop((user, slot), None))
+        """Cancel the pending timer for a habit slot."""
+        self._cancel_handle(self._timers.pop((user, self._habit_key(slot)), None))
+
+    def cancel_mood(self, user: str) -> None:
+        """Cancel the pending mood timer for a user."""
+        self._cancel_handle(self._timers.pop((user, "mood"), None))
 
     def remove(self, user: str, slot: int) -> None:
         """Remove schedules for a retired slot."""
@@ -62,9 +86,35 @@ class ReminderManager:
             self._cancel_handle(handle)
         self._timers.clear()
 
+    def _schedule(
+        self,
+        user: str,
+        timer_key: str,
+        *,
+        fire_at: datetime,
+        reminder_index: int,
+        final_index: int,
+        now: datetime,
+        **callback_kwargs: Any,
+    ) -> None:
+        self._cancel_handle(self._timers.pop((user, timer_key), None))
+        delay = max(0, (fire_at - now).total_seconds())
+        self._timers[(user, timer_key)] = self._scheduler.run_in(
+            self._callback,
+            delay,
+            user=user,
+            reminder_index=reminder_index,
+            final_index=final_index,
+            **callback_kwargs,
+        )
+
     def _cancel_handle(self, handle: str | None) -> None:
         if handle is not None:
             self._scheduler.cancel_timer(handle)
+
+    @staticmethod
+    def _habit_key(slot: int) -> str:
+        return f"habit:{slot}"
 
 
 def repeat_fits_before_midnight(now: datetime, interval_minutes: int) -> bool:

--- a/apps/habit/reminders.py
+++ b/apps/habit/reminders.py
@@ -1,4 +1,4 @@
-"""Reminder scheduling with cancellable repeat chains."""
+"""Reminder scheduling from absolute next-fire datetimes."""
 
 from __future__ import annotations
 
@@ -9,16 +9,7 @@ from typing import Any, Protocol
 class Scheduler(Protocol):
     """AppDaemon timer methods used by the reminder manager."""
 
-    def run_daily(
-        self,
-        callback: Any,
-        start: time,
-        **kwargs: Any,
-    ) -> str:
-        """Register a daily callback."""
-        ...
-
-    def run_in(self, callback: Any, delay: int, **kwargs: Any) -> str:
+    def run_in(self, callback: Any, delay: float, **kwargs: Any) -> str:
         """Register a delayed callback."""
         ...
 
@@ -28,72 +19,48 @@ class Scheduler(Protocol):
 
 
 class ReminderManager:
-    """Manage daily schedules and per-habit repeat timers."""
+    """Manage one cancellable absolute-time timer per habit slot."""
 
     def __init__(self, scheduler: Scheduler, callback: Any) -> None:
         self._scheduler = scheduler
         self._callback = callback
-        self._daily: dict[tuple[str, int], str] = {}
-        self._repeats: dict[tuple[str, int], str] = {}
+        self._timers: dict[tuple[str, int], str] = {}
 
-    def schedule_daily(self, user: str, slot: int, reminder_time: str) -> None:
-        """Replace the daily schedule for a habit."""
-        key = (user, slot)
-        self._cancel_handle(self._daily.pop(key, None))
-        parsed = time.fromisoformat(reminder_time)
-        self._daily[key] = self._scheduler.run_daily(
-            self._callback,
-            parsed,
-            user=user,
-            slot=slot,
-            reminder_index=1,
-        )
-
-    def schedule_next_repeat(
+    def schedule_at(
         self,
         user: str,
         slot: int,
         *,
-        next_index: int,
+        fire_at: datetime,
+        reminder_index: int,
         final_index: int,
-        interval_minutes: int,
         now: datetime,
-    ) -> bool:
-        """Schedule only the next repeat when it fits before the cutoff."""
-        self.cancel_repeats(user, slot)
-        if next_index > final_index or not repeat_fits_before_midnight(
-            now,
-            interval_minutes,
-        ):
-            return False
-        key = (user, slot)
-        self._repeats[key] = self._scheduler.run_in(
+    ) -> None:
+        """Replace the pending timer for a habit with an absolute fire time."""
+        self.cancel(user, slot)
+        delay = max(0, (fire_at - now).total_seconds())
+        self._timers[(user, slot)] = self._scheduler.run_in(
             self._callback,
-            interval_minutes * 60,
+            delay,
             user=user,
             slot=slot,
-            reminder_index=next_index,
+            reminder_index=reminder_index,
             final_index=final_index,
         )
-        return True
 
-    def cancel_repeats(self, user: str, slot: int) -> None:
-        """Cancel pending repeats after completion."""
-        self._cancel_handle(self._repeats.pop((user, slot), None))
+    def cancel(self, user: str, slot: int) -> None:
+        """Cancel the pending timer for a slot."""
+        self._cancel_handle(self._timers.pop((user, slot), None))
 
     def remove(self, user: str, slot: int) -> None:
-        """Remove all schedules for a retired slot."""
-        self.cancel_repeats(user, slot)
-        self._cancel_handle(self._daily.pop((user, slot), None))
+        """Remove schedules for a retired slot."""
+        self.cancel(user, slot)
 
     def cancel_all(self) -> None:
         """Cancel all managed timers."""
-        for handle in self._daily.values():
+        for handle in self._timers.values():
             self._cancel_handle(handle)
-        for handle in self._repeats.values():
-            self._cancel_handle(handle)
-        self._daily.clear()
-        self._repeats.clear()
+        self._timers.clear()
 
     def _cancel_handle(self, handle: str | None) -> None:
         if handle is not None:

--- a/apps/habit/reminders.py
+++ b/apps/habit/reminders.py
@@ -1,0 +1,111 @@
+"""Reminder scheduling with cancellable repeat chains."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+from typing import Any, Protocol
+
+
+class Scheduler(Protocol):
+    """AppDaemon timer methods used by the reminder manager."""
+
+    def run_daily(
+        self,
+        callback: Any,
+        start: time,
+        **kwargs: Any,
+    ) -> str:
+        """Register a daily callback."""
+        ...
+
+    def run_in(self, callback: Any, delay: int, **kwargs: Any) -> str:
+        """Register a delayed callback."""
+        ...
+
+    def cancel_timer(self, handle: str) -> bool:
+        """Cancel a timer."""
+        ...
+
+
+class ReminderManager:
+    """Manage daily schedules and per-habit repeat timers."""
+
+    def __init__(self, scheduler: Scheduler, callback: Any) -> None:
+        self._scheduler = scheduler
+        self._callback = callback
+        self._daily: dict[tuple[str, int], str] = {}
+        self._repeats: dict[tuple[str, int], str] = {}
+
+    def schedule_daily(self, user: str, slot: int, reminder_time: str) -> None:
+        """Replace the daily schedule for a habit."""
+        key = (user, slot)
+        self._cancel_handle(self._daily.pop(key, None))
+        parsed = time.fromisoformat(reminder_time)
+        self._daily[key] = self._scheduler.run_daily(
+            self._callback,
+            parsed,
+            user=user,
+            slot=slot,
+            reminder_index=1,
+        )
+
+    def schedule_next_repeat(
+        self,
+        user: str,
+        slot: int,
+        *,
+        next_index: int,
+        final_index: int,
+        interval_minutes: int,
+        now: datetime,
+    ) -> bool:
+        """Schedule only the next repeat when it fits before the cutoff."""
+        self.cancel_repeats(user, slot)
+        if next_index > final_index or not repeat_fits_before_midnight(
+            now,
+            interval_minutes,
+        ):
+            return False
+        key = (user, slot)
+        self._repeats[key] = self._scheduler.run_in(
+            self._callback,
+            interval_minutes * 60,
+            user=user,
+            slot=slot,
+            reminder_index=next_index,
+            final_index=final_index,
+        )
+        return True
+
+    def cancel_repeats(self, user: str, slot: int) -> None:
+        """Cancel pending repeats after completion."""
+        self._cancel_handle(self._repeats.pop((user, slot), None))
+
+    def remove(self, user: str, slot: int) -> None:
+        """Remove all schedules for a retired slot."""
+        self.cancel_repeats(user, slot)
+        self._cancel_handle(self._daily.pop((user, slot), None))
+
+    def cancel_all(self) -> None:
+        """Cancel all managed timers."""
+        for handle in self._daily.values():
+            self._cancel_handle(handle)
+        for handle in self._repeats.values():
+            self._cancel_handle(handle)
+        self._daily.clear()
+        self._repeats.clear()
+
+    def _cancel_handle(self, handle: str | None) -> None:
+        if handle is not None:
+            self._scheduler.cancel_timer(handle)
+
+
+def repeat_fits_before_midnight(now: datetime, interval_minutes: int) -> bool:
+    """Apply the legacy cutoff: midnight minus interval plus five minutes."""
+    next_midnight = datetime.combine(
+        now.date() + timedelta(days=1),
+        time(),
+        tzinfo=now.tzinfo,
+    )
+    cutoff = next_midnight - timedelta(minutes=interval_minutes + 5)
+    return now < cutoff

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import threading
+import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +34,7 @@ class HabitStore:
         self.users = users
         self._log = log
         self._error = error
+        self._lock = threading.Lock()
         self.data = self._load()
 
     def _load(self) -> StoreData:
@@ -75,26 +78,28 @@ class HabitStore:
 
     def save(self) -> None:
         """Atomically persist current data and retain the previous valid version."""
-        payload = json.dumps(
-            self.data.to_dict(),
-            indent=2,
-            sort_keys=True,
-        )
-        temporary = self.directory / f".store-{os.getpid()}.tmp"
-        temporary.write_text(f"{payload}\n", encoding="utf-8")
-        temporary.chmod(0o600)
-        with temporary.open("r+", encoding="utf-8") as file:
-            file.flush()
-            os.fsync(file.fileno())
-        if self.path.exists():
-            shutil.copy2(self.path, self.backup_path)
-        temporary.replace(self.path)
-        self.path.chmod(0o600)
-        directory_fd = os.open(self.directory, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        with self._lock:
+            self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+            payload = json.dumps(
+                self.data.to_dict(),
+                indent=2,
+                sort_keys=True,
+            )
+            temporary = self.directory / f".store-{os.getpid()}-{uuid.uuid4().hex}.tmp"
+            temporary.write_text(f"{payload}\n", encoding="utf-8")
+            temporary.chmod(0o600)
+            with temporary.open("r+", encoding="utf-8") as file:
+                file.flush()
+                os.fsync(file.fileno())
+            if self.path.exists():
+                shutil.copy2(self.path, self.backup_path)
+            temporary.replace(self.path)
+            self.path.chmod(0o600)
+            directory_fd = os.open(self.directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
 
     def _quarantine(self, path: Path) -> None:
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -11,32 +11,57 @@ from typing import TYPE_CHECKING, Any
 from .models import StoreData
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
 class HabitStore:
     """Own a recoverable, atomically-written habit store."""
 
-    def __init__(self, directory: Path, users: tuple[str, ...]) -> None:
+    def __init__(
+        self,
+        directory: Path,
+        users: tuple[str, ...],
+        *,
+        log: Callable[[str], None],
+        error: Callable[[str], None],
+    ) -> None:
         self.directory = directory
         self.path = directory / "store.json"
         self.backup_path = directory / "store.json.backup"
         self.users = users
+        self._log = log
+        self._error = error
         self.data = self._load()
 
     def _load(self) -> StoreData:
         self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        saw_unreadable = False
         for candidate in (self.path, self.backup_path):
             try:
                 data = self._read(candidate)
             except FileNotFoundError:
                 continue
-            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                saw_unreadable = True
+                self._error(
+                    "Habit store candidate "
+                    f"{candidate} is unreadable ({type(exc).__name__}: {exc}); "
+                    "quarantining",
+                )
                 self._quarantine(candidate)
             else:
                 for user in self.users:
                     data.users.setdefault(user, StoreData.empty((user,)).users[user])
                 return data
+        if saw_unreadable:
+            self._error(
+                "No readable habit store found (primary and backup exhausted); "
+                "starting with an empty store — habit configs and history may "
+                "have been lost",
+            )
+        else:
+            self._log("No habit store found; starting with an empty store")
         return StoreData.empty(self.users)
 
     @staticmethod
@@ -73,10 +98,13 @@ class HabitStore:
 
     def _quarantine(self, path: Path) -> None:
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        destination = path.with_name(f"{path.name}.invalid-{timestamp}")
         try:
-            path.replace(path.with_name(f"{path.name}.invalid-{timestamp}"))
-        except OSError:
+            path.replace(destination)
+        except OSError as exc:
+            self._error(f"Failed to quarantine habit store {path}: {exc}")
             return
+        self._error(f"Quarantined unreadable habit store at {destination}")
 
     def append_completion_log(
         self,

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -22,7 +22,6 @@ class HabitStore:
         self.path = directory / "store.json"
         self.backup_path = directory / "store.json.backup"
         self.users = users
-        self.existed = self.path.exists()
         self.data = self._load()
 
     def _load(self) -> StoreData:

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from .models import StoreData
+from .models import StoreData, UnsupportedSchemaVersionError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,6 +45,16 @@ class HabitStore:
                 data = self._read(candidate)
             except FileNotFoundError:
                 continue
+            except UnsupportedSchemaVersionError as exc:
+                # Intact data written by a different build. Quarantining would
+                # rename it and the next save would replace it with an empty
+                # store, so refuse to start and leave the file untouched.
+                self._error(
+                    f"Habit store {candidate} was written by an incompatible "
+                    f"build ({exc}); refusing to start so the file is not "
+                    "overwritten. Restore a compatible store or upgrade the app",
+                )
+                raise
             except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
                 saw_unreadable = True
                 self._error(

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -1,0 +1,103 @@
+"""Atomic JSON persistence for habit configuration and history."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from .models import StoreData
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class HabitStore:
+    """Own a recoverable, atomically-written habit store."""
+
+    def __init__(self, directory: Path, users: tuple[str, ...]) -> None:
+        self.directory = directory
+        self.path = directory / "store.json"
+        self.backup_path = directory / "store.json.backup"
+        self.users = users
+        self.existed = self.path.exists()
+        self.data = self._load()
+
+    def _load(self) -> StoreData:
+        self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        for candidate in (self.path, self.backup_path):
+            try:
+                data = self._read(candidate)
+            except FileNotFoundError:
+                continue
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                self._quarantine(candidate)
+            else:
+                for user in self.users:
+                    data.users.setdefault(user, StoreData.empty((user,)).users[user])
+                return data
+        return StoreData.empty(self.users)
+
+    @staticmethod
+    def _read(path: Path) -> StoreData:
+        payload: object = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise TypeError("store root must be an object")
+        return StoreData.from_dict(
+            {str(key): value for key, value in payload.items()},
+        )
+
+    def save(self) -> None:
+        """Atomically persist current data and retain the previous valid version."""
+        payload = json.dumps(
+            self.data.to_dict(),
+            indent=2,
+            sort_keys=True,
+        )
+        temporary = self.directory / f".store-{os.getpid()}.tmp"
+        temporary.write_text(f"{payload}\n", encoding="utf-8")
+        temporary.chmod(0o600)
+        with temporary.open("r+", encoding="utf-8") as file:
+            file.flush()
+            os.fsync(file.fileno())
+        if self.path.exists():
+            shutil.copy2(self.path, self.backup_path)
+        temporary.replace(self.path)
+        self.path.chmod(0o600)
+        directory_fd = os.open(self.directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _quarantine(self, path: Path) -> None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        try:
+            path.replace(path.with_name(f"{path.name}.invalid-{timestamp}"))
+        except OSError:
+            return
+
+    def append_completion_log(
+        self,
+        user: str,
+        slot: int,
+        day: str,
+        count: int,
+    ) -> None:
+        """Append a durable audit record after a completion mutation."""
+        record: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "user": user,
+            "slot": slot,
+            "date": day,
+            "count": count,
+        }
+        path = self.directory / "completions.jsonl"
+        with path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(record, sort_keys=True))
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        path.chmod(0o600)

--- a/apps/habit/templates.py
+++ b/apps/habit/templates.py
@@ -57,19 +57,15 @@ def coerce_truthy(value: object) -> bool | None:
         return value
     if isinstance(value, int | float):
         return value > 0
-    if value is None:
-        return False
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in TRUTHY_STRINGS:
-            return True
-        if normalized in FALSY_STRINGS:
-            return False
-        try:
-            return float(normalized) > 0
-        except ValueError:
-            return None
-    return None
+    if not isinstance(value, str):
+        return False if value is None else None
+    normalized = value.strip().lower()
+    if normalized in TRUTHY_STRINGS | FALSY_STRINGS:
+        return normalized in TRUTHY_STRINGS
+    try:
+        return float(normalized) > 0
+    except ValueError:
+        return None
 
 
 class TemplateScheduler(Protocol):

--- a/apps/habit/templates.py
+++ b/apps/habit/templates.py
@@ -1,0 +1,158 @@
+"""Template dependency extraction, truthiness coercion, and listener bookkeeping."""
+
+from __future__ import annotations
+
+import re
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, Final, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Matches a bare `domain.object_id` pair. The lookaround refuses to match
+# inside a longer dotted chain such as `states.sensor.foo`, which has no single
+# entity dependency to subscribe to.
+ENTITY_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"(?<![\w.])([a-z_][a-z0-9_]*)\.([a-z0-9_]+)(?![\w.])",
+)
+
+TRUTHY_STRINGS: Final[frozenset[str]] = frozenset({"true", "on", "yes", "1"})
+FALSY_STRINGS: Final[frozenset[str]] = frozenset(
+    {
+        "",
+        "0",
+        "false",
+        "no",
+        "none",
+        "null",
+        "off",
+        "unavailable",
+        "unknown",
+    },
+)
+
+
+def extract_candidate_entities(template: str) -> tuple[str, ...]:
+    """Return unique `domain.object_id` candidates in first-seen order.
+
+    These are candidates only: the pattern cannot tell an entity reference from
+    an attribute access such as `value.split`. Callers filter against real
+    Home Assistant state before subscribing.
+    """
+    seen: dict[str, None] = {}
+    for match in ENTITY_PATTERN.finditer(template):
+        seen.setdefault(f"{match.group(1)}.{match.group(2)}", None)
+    return tuple(seen)
+
+
+def coerce_truthy(value: object) -> bool | None:
+    """Coerce a rendered template result to a boolean.
+
+    Returns ``None`` when the value is not recognisable, so the caller can log
+    it once and fall back to False. Home Assistant returns a native bool for a
+    single pure expression but a string for anything else, and ``bool("False")``
+    is ``True``, so results must never be tested directly.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value > 0
+    if value is None:
+        return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in TRUTHY_STRINGS:
+            return True
+        if normalized in FALSY_STRINGS:
+            return False
+        try:
+            return float(normalized) > 0
+        except ValueError:
+            return None
+    return None
+
+
+class TemplateScheduler(Protocol):
+    """AppDaemon methods used by the template watcher."""
+
+    def run_in(self, callback: Any, delay: float, **kwargs: Any) -> str:
+        """Register a delayed callback."""
+        ...
+
+    def cancel_timer(self, handle: str, *, silent: bool = False) -> bool:
+        """Cancel a timer."""
+        ...
+
+    def listen_state(self, callback: Any, entity_id: Any, **kwargs: Any) -> Any:
+        """Subscribe to state changes for an entity."""
+        ...
+
+    def cancel_listen_state(self, handle: Any) -> Any:
+        """Cancel a state subscription."""
+        ...
+
+
+class TemplateWatcher:
+    """Own per-slot state subscriptions and one debounced evaluation timer."""
+
+    def __init__(
+        self,
+        scheduler: TemplateScheduler,
+        on_change: Any,
+        on_evaluate: Any,
+    ) -> None:
+        self._scheduler = scheduler
+        self._on_change = on_change
+        self._on_evaluate = on_evaluate
+        self._listeners: dict[tuple[str, int], tuple[Any, ...]] = {}
+        self._pending: dict[tuple[str, int], str] = {}
+
+    def watch(self, user: str, slot: int, entities: Iterable[str]) -> tuple[str, ...]:
+        """Replace the subscriptions for a slot and return what is watched."""
+        self.unwatch(user, slot)
+        watched = tuple(dict.fromkeys(entities))
+        handles = [
+            self._scheduler.listen_state(self._on_change, entity, user=user, slot=slot)
+            for entity in watched
+        ]
+        if handles:
+            self._listeners[(user, slot)] = tuple(handles)
+        return watched
+
+    def unwatch(self, user: str, slot: int) -> None:
+        """Drop every subscription for a slot."""
+        for handle in self._listeners.pop((user, slot), ()):
+            with suppress(Exception):
+                self._scheduler.cancel_listen_state(handle)
+
+    def schedule(self, user: str, slot: int, delay: float) -> None:
+        """Debounce an evaluation, replacing any already-pending one."""
+        self.cancel_scheduled(user, slot)
+        self._pending[(user, slot)] = self._scheduler.run_in(
+            self._on_evaluate,
+            delay,
+            user=user,
+            slot=slot,
+        )
+
+    def cancel_scheduled(self, user: str, slot: int) -> None:
+        """Cancel a pending evaluation for a slot."""
+        handle = self._pending.pop((user, slot), None)
+        if handle is not None:
+            self._scheduler.cancel_timer(handle, silent=True)
+
+    def release(self, user: str, slot: int) -> None:
+        """Drop an evaluation handle that has already fired."""
+        self._pending.pop((user, slot), None)
+
+    def remove(self, user: str, slot: int) -> None:
+        """Forget a retired slot entirely."""
+        self.cancel_scheduled(user, slot)
+        self.unwatch(user, slot)
+
+    def cancel_all(self) -> None:
+        """Cancel every subscription and pending evaluation."""
+        for user, slot in list(self._pending):
+            self.cancel_scheduled(user, slot)
+        for user, slot in list(self._listeners):
+            self.unwatch(user, slot)

--- a/apps/habit/templates.py
+++ b/apps/habit/templates.py
@@ -89,19 +89,22 @@ class TemplateScheduler(Protocol):
 
 
 class TemplateWatcher:
-    """Own per-slot state subscriptions and one debounced evaluation timer."""
+    """Own per-slot state subscriptions, evaluation timers, and duration timers."""
 
     def __init__(
         self,
         scheduler: TemplateScheduler,
         on_change: Any,
         on_evaluate: Any,
+        on_duration: Any,
     ) -> None:
         self._scheduler = scheduler
         self._on_change = on_change
         self._on_evaluate = on_evaluate
+        self._on_duration = on_duration
         self._listeners: dict[tuple[str, int], tuple[Any, ...]] = {}
         self._pending: dict[tuple[str, int], str] = {}
+        self._durations: dict[tuple[str, int], str] = {}
 
     def watch(self, user: str, slot: int, entities: Iterable[str]) -> tuple[str, ...]:
         """Replace the subscriptions for a slot and return what is watched."""
@@ -141,14 +144,37 @@ class TemplateWatcher:
         """Drop an evaluation handle that has already fired."""
         self._pending.pop((user, slot), None)
 
+    def arm_duration(self, user: str, slot: int, delay: float) -> None:
+        """Replace the duration timer for a slot."""
+        self.cancel_duration(user, slot)
+        self._durations[(user, slot)] = self._scheduler.run_in(
+            self._on_duration,
+            delay,
+            user=user,
+            slot=slot,
+        )
+
+    def cancel_duration(self, user: str, slot: int) -> None:
+        """Cancel the duration timer for a slot."""
+        handle = self._durations.pop((user, slot), None)
+        if handle is not None:
+            self._scheduler.cancel_timer(handle, silent=True)
+
+    def release_duration(self, user: str, slot: int) -> None:
+        """Drop a duration handle that has already fired."""
+        self._durations.pop((user, slot), None)
+
     def remove(self, user: str, slot: int) -> None:
         """Forget a retired slot entirely."""
         self.cancel_scheduled(user, slot)
+        self.cancel_duration(user, slot)
         self.unwatch(user, slot)
 
     def cancel_all(self) -> None:
-        """Cancel every subscription and pending evaluation."""
+        """Cancel every subscription and pending timer."""
         for user, slot in list(self._pending):
             self.cancel_scheduled(user, slot)
+        for user, slot in list(self._durations):
+            self.cancel_duration(user, slot)
         for user, slot in list(self._listeners):
             self.unwatch(user, slot)


### PR DESCRIPTION


---



- 65254cd | feat(habit): add habit and mood tracking to Home Assistant
- 962f5c6 | refactor(habit): remove legacy migration code for habit helpers
- 1f5d7ed | feat(habit): improve streak algorithm for weekly grace flexibility
- fc98d0f | refactor: remove test reminder button support
- 6100411 | refactor: simplify habit tracker config
- 8d05050 | feat: enable habit reminders
- 12b8765 | feat: improve reminder management for habits
- 6238ea6 | feat: enhance mood reminder system
- 43b16b6 | fix: ensure timezone awareness in reminders
- 7ed932f | feat: improve reminder persistence and safety
- 4ca3a66 | fix: ensure consistent UTC handling for reminders
- 203780b | feat: add toggle for mood reminders
- 465d112 | feat: streamline habit reminder notifications
- c383be0 | feat: enhance AI reminders for habits and moods
- 3f6ee6f | refactor: unify reminder context usage
- c445dd3 | feat: enhance date formatting
- c5c64ae | refactor: simplify context handling
- bef4153 | feat: add schema version migration handling
- 7010faa | feat: support event-driven habit completion
- 1e3762b | feat: add template-driven habit completion
- eb68595 | feat: outline event-driven habit plan
- 9816191 | refactor(habit): enhance local context representation for AI
- b128501 | fix(habit): prevent inheritance of old settings in empty slots
- 7cce9de | feat(habit): enable duration-based template evaluations
- 7eb4f40 | refactor(habit): simplify MQTT logic for habit completion
