### PR TITLE
feat: add SLC timestamp sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Student Loan (SLC)
 
 `apps/slc/slc_balance.py` polls the UK Student Loans Company account overview and
-publishes six Home Assistant MQTT sensors under one `Student Loan` device.
+publishes eight Home Assistant MQTT sensors under one `Student Loan` device.
 
 ### AppDaemon Runtime Dependencies
 
@@ -32,10 +32,12 @@ appdaemon_mqtt_password: <mqtt password>
 
 - `sensor.slc_balance`
 - `sensor.slc_interest_rate`
+- `sensor.slc_as_of_date`
 - `sensor.slc_current_year`
 - `sensor.slc_salary_repayments`
 - `sensor.slc_direct_repayments`
 - `sensor.slc_interest_added`
+- `sensor.slc_last_successful_scrape`
 
 Optional diagnostic entity: `sensor.slc_last_poll`.
 

--- a/apps/slc/slc_balance.py
+++ b/apps/slc/slc_balance.py
@@ -32,6 +32,7 @@ class SensorSpec:
         unit_of_measurement: Optional unit published in discovery.
         device_class: Optional Home Assistant device class.
         state_class: Optional Home Assistant state class.
+        entity_category: Optional Home Assistant entity category.
     """
 
     key: str
@@ -41,6 +42,7 @@ class SensorSpec:
     unit_of_measurement: str | None = None
     device_class: str | None = None
     state_class: str | None = None
+    entity_category: str | None = None
 
 
 SENSORS: Final[tuple[SensorSpec, ...]] = (
@@ -60,6 +62,13 @@ SENSORS: Final[tuple[SensorSpec, ...]] = (
         name="Interest rate",
         unit_of_measurement="%",
         state_class="measurement",
+    ),
+    SensorSpec(
+        key="as_of_date",
+        object_id="slc_as_of_date",
+        unique_id="appdaemon_slc_as_of_date",
+        name="As of date",
+        device_class="date",
     ),
     SensorSpec(
         key="current_year",
@@ -94,6 +103,14 @@ SENSORS: Final[tuple[SensorSpec, ...]] = (
         device_class="monetary",
         state_class="total",
     ),
+    SensorSpec(
+        key="last_successful_scrape",
+        object_id="slc_last_successful_scrape",
+        unique_id="appdaemon_slc_last_successful_scrape",
+        name="Last successful scrape",
+        device_class="timestamp",
+        entity_category="diagnostic",
+    ),
 )
 
 
@@ -101,7 +118,7 @@ class SlcBalance(hass.Hass):
     """Publish Student Loans Company overview values as MQTT sensors.
 
     The app authenticates to the SLC portal on a schedule, publishes retained
-    MQTT discovery/state for six sensors under one device, and notifies via
+    MQTT discovery/state for eight sensors under one device, and notifies via
     ``script.notify_will`` after repeated poll failures.
     """
 
@@ -192,14 +209,15 @@ class SlcBalance(hass.Hass):
             self._set_availability(is_available=False, error=str(err))
             return
 
-        self._publish_sensor_states(summary)
+        self._publish_sensor_states(summary, scraped_at=datetime.now(UTC))
         self._write_raw_sensor("ok", summary=summary)
         self._set_availability(is_available=True)
         self._clear_failure_notification()
         self.log(
-            "Published SLC overview (balance present=%s, year=%s)",
+            "Published SLC overview (balance present=%s, year=%s, as_of=%s)",
             summary.balance is not None,
             summary.current_year or "n/a",
+            summary.as_of_date.isoformat() if summary.as_of_date else "n/a",
         )
 
     def _configure_mqtt(self) -> None:
@@ -372,6 +390,8 @@ class SlcBalance(hass.Hass):
                 config["device_class"] = sensor.device_class
             if sensor.state_class is not None:
                 config["state_class"] = sensor.state_class
+            if sensor.entity_category is not None:
+                config["entity_category"] = sensor.entity_category
 
             config_topic = (
                 f"{self.mqtt_discovery_prefix}/sensor/{sensor.object_id}/config"
@@ -389,12 +409,19 @@ class SlcBalance(hass.Hass):
             "online" if is_available else "offline",
         )
 
-    def _value_for_sensor(self, summary: LoanSummary, key: str) -> str | None:
+    def _value_for_sensor(
+        self,
+        summary: LoanSummary,
+        key: str,
+        *,
+        scraped_at: datetime,
+    ) -> str | None:
         """Format a loan-summary field for MQTT state publication.
 
         Args:
             summary: Parsed SLC overview values.
             key: Sensor key from ``SensorSpec.key``.
+            scraped_at: UTC datetime of the successful scrape.
 
         Returns:
             String state payload, or None if the value is missing/unknown.
@@ -405,6 +432,9 @@ class SlcBalance(hass.Hass):
                 None
                 if summary.interest_rate_pct is None
                 else f"{summary.interest_rate_pct:g}"
+            ),
+            "as_of_date": (
+                None if summary.as_of_date is None else summary.as_of_date.isoformat()
             ),
             "current_year": summary.current_year,
             "salary_repayments": (
@@ -422,20 +452,27 @@ class SlcBalance(hass.Hass):
                 if summary.interest_added is None
                 else f"{summary.interest_added:.2f}"
             ),
+            "last_successful_scrape": scraped_at.isoformat(),
         }
         return values.get(key)
 
-    def _publish_sensor_states(self, summary: LoanSummary) -> None:
+    def _publish_sensor_states(
+        self,
+        summary: LoanSummary,
+        *,
+        scraped_at: datetime,
+    ) -> None:
         """Publish retained MQTT state topics for all known sensor values.
 
         Args:
             summary: Parsed SLC overview values.
+            scraped_at: UTC datetime of the successful scrape.
         """
         if self.mqtt_client is None:
             return
 
         for sensor in SENSORS:
-            value = self._value_for_sensor(summary, sensor.key)
+            value = self._value_for_sensor(summary, sensor.key, scraped_at=scraped_at)
             if value is None:
                 continue
             self._publish_mqtt(self._mqtt_topic(f"{sensor.key}/state"), value)
@@ -464,6 +501,9 @@ class SlcBalance(hass.Hass):
             attributes["current_year"] = summary.current_year
             attributes["balance"] = summary.balance
             attributes["interest_rate_pct"] = summary.interest_rate_pct
+            attributes["as_of_date"] = (
+                summary.as_of_date.isoformat() if summary.as_of_date else None
+            )
             attributes["salary_repayments"] = summary.salary_repayments
             attributes["direct_repayments"] = summary.direct_repayments
             attributes["interest_added"] = summary.interest_added

--- a/apps/slc/slc_client.py
+++ b/apps/slc/slc_client.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import date, datetime
 from html import unescape
 from urllib.parse import urljoin
+from zoneinfo import ZoneInfo
 
 import httpx2
 
@@ -33,6 +35,7 @@ class LoanSummary:
     Attributes:
         balance: Outstanding loan balance in GBP, if present.
         interest_rate_pct: Current interest rate as a percentage, if present.
+        as_of_date: Balance/interest "as of" date from the portal, if present.
         current_year: Academic year label for the summary section, if present.
         salary_repayments: Salary repayments for the year in GBP, if present.
         direct_repayments: Direct repayments for the year in GBP, if present.
@@ -41,6 +44,7 @@ class LoanSummary:
 
     balance: float | None
     interest_rate_pct: float | None
+    as_of_date: date | None
     current_year: str | None
     salary_repayments: float | None
     direct_repayments: float | None
@@ -214,6 +218,39 @@ def _parse_percent(text: str | None) -> float | None:
         return None
 
 
+def _parse_as_of_date(text: str | None) -> date | None:
+    """Parse the portal "as of" date from interest-rate text.
+
+    Accepts formats such as ``as of 26 July 2026`` and ``as of 01/01/2026``.
+
+    Args:
+        text: Text that may contain an "as of" date phrase.
+
+    Returns:
+        Parsed calendar date, or None if no supported date is found.
+    """
+    if not text:
+        return None
+    match = re.search(
+        r"as\s+of\s+(\d{1,2}\s+[A-Za-z]+\s+\d{4}|\d{1,2}/\d{1,2}/\d{4})",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+    raw = match.group(1)
+    for fmt in ("%d %B %Y", "%d %b %Y", "%d/%m/%Y"):
+        try:
+            return (
+                datetime.strptime(raw, fmt)
+                .replace(tzinfo=ZoneInfo("Europe/London"))
+                .date()
+            )
+        except ValueError:
+            continue
+    return None
+
+
 def parse_overview(html: str) -> LoanSummary:
     """Parse account overview HTML into structured fields.
 
@@ -227,7 +264,9 @@ def parse_overview(html: str) -> LoanSummary:
         SlcError: If the outstanding balance element cannot be parsed.
     """
     balance = _parse_money(_element_text_by_id(html, "balanceId_1"))
-    interest_rate = _parse_percent(_element_text_by_id(html, "interestAsOfDateId-1"))
+    interest_text = _element_text_by_id(html, "interestAsOfDateId-1")
+    interest_rate = _parse_percent(interest_text)
+    as_of_date = _parse_as_of_date(interest_text)
     year_text = _element_text_by_id(html, "academicYearSummaryId-1")
     current_year = None
     if year_text:
@@ -238,6 +277,7 @@ def parse_overview(html: str) -> LoanSummary:
     summary = LoanSummary(
         balance=balance,
         interest_rate_pct=interest_rate,
+        as_of_date=as_of_date,
         current_year=current_year,
         salary_repayments=_parse_money(
             _element_text_by_id(html, "salaryRepaymentAmountId-1"),


### PR DESCRIPTION


---



- 202d2b3 | feat: add SLC timestamp sensors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two Student Loan MQTT sensors: “as of” date and last successful scrape timestamp.
  * Added diagnostic categorization for the last successful scrape sensor.
  * Student Loan data now includes the date the loan information was current as of.

* **Documentation**
  * Updated Home Assistant documentation to reflect the expanded set of eight Student Loan sensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->