### PR TITLE
feat: enhance mood tracking with new features

### DIFF
--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -71,6 +71,8 @@ habit_tracker:
     will:
       notify_script: script.notify_will
       dashboard_url: /home-will/health-fitness
+      mood_reminders_default: true
+      mood_context_prompts_default: true
       person_entity: person.will
       at_work_entity: binary_sensor.will_at_work
       workday_entity: binary_sensor.workday
@@ -79,6 +81,8 @@ habit_tracker:
     vic:
       notify_script: script.notify_vic
       dashboard_url: /dashboard-mobile/vic-habits
+      mood_reminders_default: false
+      mood_context_prompts_default: false
       person_entity: person.vic
       at_work_entity: binary_sensor.vic_at_work
       workday_entity: binary_sensor.workday

--- a/apps/habit/README.md
+++ b/apps/habit/README.md
@@ -47,12 +47,19 @@ Each user also receives:
 - `select.<user>_mood_today`
 - `text.<user>_mood_note`
 - `sensor.<user>_mood_streak`
+- `sensor.<user>_mood_summary` (seven-day cards and compact 28-day chart data)
+- `switch.<user>_mood_context_prompts`
+- `number.<user>_mood_context_cooldown`
 - `time.<user>_mood_reminder_time` (daily template for the first fire)
 - `switch.<user>_mood_reminders` (enable/disable mood reminder notifications)
 - `datetime.<user>_mood_next_reminder` (editable absolute fire time)
 - `number.<user>_mood_repeat_count` and `number.<user>_mood_repeat_interval`
 - `sensor.<user>_habits_binary_count` and `sensor.<user>_habits_countable_count`
   (configured inventory counts by habit type; spare/unnamed slots are excluded)
+
+The existing unsuffixed mood select, note, streak, and reminder IDs are preserved.
+Hidden editor entities expose a selected check-in, logical date, optional time, mood,
+note, save action, and delete action for the current and previous six logical days.
 
 ## Persistence
 
@@ -65,6 +72,22 @@ The default data directory is:
 `store.json` is the source of truth. Writes are atomic, the previous valid file is
 retained as `store.json.backup`, and invalid files are quarantined. Completion changes
 are additionally appended to `completions.jsonl`.
+
+Mood data uses schema v3 timestamped check-ins. Each record has a stable ID, logical
+date, optional occurrence time, mood, note, source, and audit timestamps. Logical mood
+days run from 04:00 to 03:59 in `Europe/London`; entries and notes are retained
+indefinitely, while changes are limited to the current and previous six logical days.
+Migration from schema v2 is deterministic, keeps unknown historical times empty,
+attaches the current note to its matching entry, and writes a one-time
+`store.json.schema-v2-backup` before accepting v3 writes. Mood mutations are also
+written to `mood-checkins.jsonl`.
+
+Daily mood summaries include average, minimum, maximum, count, first-to-last
+direction, and a mixed flag when the range is at least two points. Current and longest
+streaks count distinct logical days; the summary also reports 7-day and 28-day
+consistency. Completed days with notes receive a cached Qwen narrative after 04:00.
+Editing a completed day invalidates and regenerates its narrative; AI failures never
+replace or block deterministic statistics.
 
 Habit completion history is stored by local calendar date:
 
@@ -119,16 +142,21 @@ the timer.
 Mood reminders use the same durable `next_reminder` pattern with user-level
 entities (`mood_reminders`, `mood_reminder_time`, `mood_next_reminder`, repeat
 count/interval). Turning `mood_reminders` off clears any pending mood timer.
-A mood reminder is also skipped once today's mood is set, and the pending chain
-is cleared at that point. Midnight re-seeds an incomplete mood check-in for the
-new day when reminders are enabled.
+A mood reminder is also skipped once the logical day's first check-in is recorded,
+and the pending chain is cleared at that point. The 04:00 rollover re-seeds an
+incomplete mood check-in when reminders are enabled.
+
+Mood prompts are sent as a grouped low/neutral notification and a grouped positive
+notification. Both expire after 15 minutes and open the user's dashboard. Choosing a
+mood clears the pair, creates exactly one check-in through the shared write path, and
+sends a text-reply notification for a note tied to that check-in. Cleared companion
+events remove the sibling notification where the mobile app exposes them.
 
 Notifications are sent through the user's configured `script.notify_*` script. Their
 action button either marks a binary habit complete or increments a countable habit.
 
-At local midnight, current values reset while historical completions remain available
-for streak calculations. Mood and mood notes reset at the same time. Pending reminder
-chains are cleared and incomplete habits are re-seeded for the new day.
+At local midnight, habit values reset while historical completions remain available
+for streak calculations. Mood draft state and reminder scheduling roll at 04:00.
 
 ## AI reminders
 
@@ -146,6 +174,15 @@ Context can include:
 
 Unavailable context is omitted. If AI generation fails or returns an empty response,
 the app sends a deterministic fallback reminder.
+
+Mood context prompting is separate from reminder text generation. It starts only
+after the day's first check-in, uses a configurable 15–360 minute cooldown (90 minutes
+by default), coalesces triggers during the cooldown, and discards stale work. Calendar
+blocks ignore cancelled/all-day events, merge overlaps or gaps of up to 15 minutes,
+and use structured Qwen output to fail closed. Presence prompts fire 15 minutes after
+returning from work or after another outing lasting at least two hours. Outing state is
+persisted across AppDaemon restarts. Will's context prompts default on; Vic's scheduled
+and contextual prompts default off.
 
 This implementation ports the behavior from the legacy Home Assistant
 `script.habit_send_reminder`. AppDaemon becomes the source of truth after cutover;

--- a/apps/habit/habit_tracker.py
+++ b/apps/habit/habit_tracker.py
@@ -2,32 +2,48 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
+import uuid
 from contextlib import suppress
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Final, cast
+from zoneinfo import ZoneInfo
 
 import appdaemon.plugins.hass.hassapi as hass
 
 from .models import (
+    LOGICAL_DAY_BOUNDARY_HOUR,
     MAX_DURATION_MINUTES,
+    MAX_MOOD_CALENDAR_DECISIONS,
+    MAX_MOOD_NOTE_LENGTH,
+    MAX_MOOD_REQUEST_IDS,
     MAX_NAME_LENGTH,
     MAX_TEMPLATE_LENGTH,
+    MOOD_EDIT_WINDOW_DAYS,
     MOOD_OPTIONS,
     CompletionMode,
     HabitConfig,
     HabitType,
+    MoodCheckIn,
     PendingReminder,
     TemplateProgress,
     UnsupportedSchemaVersionError,
     UserData,
     calculate_mood_streak,
     calculate_streak,
+    logical_date_for,
     normalize_spare_slot,
+    summarize_mood_day,
 )
 from .mqtt import HabitMqtt, MqttSettings
-from .reminders import ReminderManager, repeat_fits_before_midnight
+from .reminders import (
+    ReminderManager,
+    repeat_fits_before_logical_day_end,
+    repeat_fits_before_midnight,
+)
 from .store import HabitStore
 from .templates import TemplateWatcher, coerce_truthy, extract_candidate_entities
 
@@ -83,11 +99,43 @@ REQUIRED_USER_KEYS: Final[tuple[str, ...]] = (
 )
 SLOT_TOPIC_PARTS: Final[int] = 4
 ACTION_PARTS: Final[int] = 3
+MOOD_CHECKIN_ACTION_PARTS: Final[int] = 4
+MOOD_NOTE_ACTION_PARTS: Final[int] = 3
 MAX_NETWORK_PORT: Final[int] = 65535
 # Ticks on the minute, so a duration-based template reconciles once a minute
 # even if one of its dependencies changes without emitting an event.
 TIME_TICK_ENTITY: Final[str] = "sensor.time"
 MAX_DEBOUNCE_SECONDS: Final[float] = 60
+LOCAL_TIMEZONE: Final[ZoneInfo] = ZoneInfo("Europe/London")
+MOOD_NOTIFICATION_TIMEOUT_SECONDS: Final[int] = 15 * 60
+MOOD_NOTE_TIMEOUT_SECONDS: Final[int] = 60 * 60
+CONTEXT_OUTING_MINUTES: Final[int] = 120
+CONTEXT_PROMPT_DELAY_MINUTES: Final[int] = 15
+CONTEXT_STALE_MINUTES: Final[int] = 120
+CALENDAR_SCAN_INTERVAL_SECONDS: Final[int] = 15 * 60
+CALENDAR_BLOCK_GAP_MINUTES: Final[int] = 15
+MOOD_SUMMARY_INSTRUCTIONS: Final[str] = """Summarize one completed mood-tracking day.
+
+Use the supplied statistics and notes as private source material. Return one neutral,
+compassionate sentence that highlights a useful pattern without diagnosing, judging,
+or inventing a cause. Do not mention scores or that an AI wrote the summary."""
+MOOD_EVENT_CLASSIFIER_INSTRUCTIONS: Final[str] = """Decide whether reflecting on mood
+after this calendar block would produce useful emotional context. Routine recurring
+admin, standups, reminders, and purely logistical entries should normally be false.
+Meaningful social, health, family, travel, performance, interview, appointment, or
+unusual work events may be true. When uncertain, return false."""
+CALENDAR_EMAIL_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b",
+    re.IGNORECASE,
+)
+CALENDAR_URL_RE: Final[re.Pattern[str]] = re.compile(r"https?://\S+", re.IGNORECASE)
+CALENDAR_PHONE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?<!\w)(?:\+?\d[\d ().-]{7,}\d)(?!\w)",
+)
+CALENDAR_OPAQUE_ID_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:[0-9a-f]{8}-[0-9a-f-]{27,}|[0-9a-f]{20,})\b",
+    re.IGNORECASE,
+)
 
 
 class HabitTracker(hass.Hass):
@@ -132,6 +180,21 @@ class HabitTracker(hass.Hass):
             return
         self._startup_retired: dict[str, tuple[int, ...]] = {}
         for user in self.users:
+            data = self.store.data.users[user]
+            if data.mood_reminders_enabled is None:
+                data.mood_reminders_enabled = bool(
+                    self._user_config(user).get(
+                        "mood_reminders_default",
+                        user == "will",
+                    ),
+                )
+            if data.mood_context_prompts_enabled is None:
+                data.mood_context_prompts_enabled = bool(
+                    self._user_config(user).get(
+                        "mood_context_prompts_default",
+                        user == "will",
+                    ),
+                )
             _, retired = self._normalize_user_slots(user)
             self._startup_retired[user] = retired
         self.store.save()
@@ -149,13 +212,48 @@ class HabitTracker(hass.Hass):
             tuple[str, int],
             dict[str, object],
         ] = {}
+        self._mood_editor: dict[str, dict[str, str]] = {}
+        self._mood_editor_ids: dict[str, dict[str, str]] = {}
+        self._calendar_scheduled: set[str] = set()
+        self._context_timers: dict[str, str] = {}
+        self._pending_context: dict[str, dict[str, object]] = {}
+        for user in self.users:
+            now = self._aware_now()
+            self._mood_editor[user] = {
+                "entry": "New check-in",
+                "date": logical_date_for(now).isoformat(),
+                "time": now.strftime("%H:%M:%S"),
+                "value": "Okay",
+                "note": "",
+            }
+            self._mood_editor_ids[user] = {}
         self._configure_mqtt()
         self.listen_event(
             self._handle_notification_action,
             "mobile_app_notification_action",
         )
+        self.listen_event(
+            self._handle_notification_cleared,
+            "mobile_app_notification_cleared",
+        )
         for user in self.users:
             self.run_daily(self._midnight_rollover, time(), user=user)
+            self.run_daily(self._logical_day_rollover, time(4), user=user)
+            self.listen_state(
+                self._presence_changed,
+                str(self._user_config(user)["person_entity"]),
+                user=user,
+            )
+            self.listen_state(
+                self._work_presence_changed,
+                str(self._user_config(user)["at_work_entity"]),
+                user=user,
+            )
+        self.run_every(
+            self._scan_context_calendars,
+            "now+60",
+            CALENDAR_SCAN_INTERVAL_SECONDS,
+        )
         # Defer arming so initialize can finish before run_in(0) callbacks save.
         self.run_in(self._restore_reminders_callback, 1)
         self.log("Habit tracker initialized for %s", ", ".join(self.users))
@@ -163,6 +261,7 @@ class HabitTracker(hass.Hass):
     def _restore_reminders_callback(self, _kwargs: dict[str, Any]) -> None:
         self._restore_reminders()
         self._restore_templates()
+        self._restore_presence_context()
         self.store.save()
 
     def _restore_templates(self) -> None:
@@ -245,7 +344,10 @@ class HabitTracker(hass.Hass):
     def _publish_all(self) -> None:
         if self.mqtt is None:
             return
-        self.mqtt.publish_mood_discovery(self.users)
+        self.mqtt.publish_mood_discovery(
+            self.users,
+            editor_options={user: self._editor_options(user) for user in self.users},
+        )
         for user in self.users:
             for retired_slot in self._startup_retired[user]:
                 self.mqtt.retire_slot(user, retired_slot)
@@ -382,12 +484,24 @@ class HabitTracker(hass.Hass):
             if counts_changed:
                 self._publish_habit_type_counts(user)
 
-    def _update_mood(self, user: str, key: str, payload: str) -> None:
+    def _update_mood(  # noqa: C901
+        self,
+        user: str,
+        key: str,
+        payload: str,
+    ) -> None:
         data = self.store.data.users[user]
         if key == "mood_today":
-            self._apply_mood_today(user, data, payload)
+            if payload != "Not Set":
+                self._create_mood_checkin(
+                    user,
+                    mood=payload,
+                    note=data.mood_note_draft,
+                    source="dashboard",
+                )
+                return
         elif key == "mood_note":
-            data.mood_note = payload[:255]
+            data.mood_note_draft = payload[:255]
         elif key == "mood_reminder_time":
             self._apply_mood_reminder_time(user, data, payload)
         elif key == "mood_reminders":
@@ -400,23 +514,231 @@ class HabitTracker(hass.Hass):
             data.mood_repeat_count = _bounded_int(payload, 0, 100)
         elif key == "mood_repeat_interval":
             data.mood_repeat_interval_minutes = _bounded_int(payload, 1, 1440)
+        elif key == "mood_context_prompts":
+            data.mood_context_prompts_enabled = _mqtt_bool(payload)
+        elif key == "mood_context_cooldown":
+            data.mood_context_cooldown_minutes = _bounded_int(payload, 15, 360)
+        elif key.startswith("mood_edit_"):
+            self._update_mood_editor(user, key, payload)
+            return
         else:
             raise KeyError(key)
         data.__post_init__()
         self.store.save()
         self._publish_mood_state(user)
 
-    def _apply_mood_today(self, user: str, data: UserData, payload: str) -> None:
-        if payload not in MOOD_OPTIONS:
+    def _create_mood_checkin(
+        self,
+        user: str,
+        *,
+        mood: str,
+        note: str,
+        source: str,
+        occurred_at: datetime | None = None,
+        logical_day: date | None = None,
+        request_id: str | None = None,
+    ) -> MoodCheckIn | None:
+        data = self.store.data.users[user]
+        if mood not in MOOD_OPTIONS[1:]:
             raise ValueError("invalid mood option")
-        today = self.datetime().date().isoformat()
-        data.mood_today = payload
-        if payload != "Not Set":
-            data.mood_history[today] = payload
+        if request_id is not None and request_id in data.mood_request_ids:
+            return None
+        now = self._aware_now()
+        occurrence = occurred_at or now
+        if occurrence.tzinfo is None:
+            occurrence = occurrence.replace(tzinfo=LOCAL_TIMEZONE)
+        occurrence = occurrence.astimezone(LOCAL_TIMEZONE)
+        target_day = logical_day or logical_date_for(occurrence)
+        self._validate_mood_edit_day(target_day, today=logical_date_for(now))
+        timestamp = datetime.now(UTC).isoformat()
+        checkin = MoodCheckIn(
+            id=uuid.uuid4().hex,
+            logical_date=target_day.isoformat(),
+            mood=mood,
+            note=note[:MAX_MOOD_NOTE_LENGTH],
+            source=source,
+            occurred_at=occurrence.isoformat(),
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+        first_for_today = not self._has_mood_for_day(data, logical_date_for(now))
+        data.mood_checkins.append(checkin)
+        data.mood_narratives.pop(checkin.logical_date, None)
+        data.mood_note_draft = ""
+        self._remember_mood_request(data, request_id)
+        if first_for_today and target_day == logical_date_for(now):
             self._clear_mood_pending(user)
+        self._finish_mood_mutation(user, "create", checkin)
+        self._clear_mood_notifications(user)
+        if target_day < logical_date_for(now):
+            self._generate_mood_narrative(user, target_day)
+        return checkin
+
+    def _update_mood_checkin(
+        self,
+        user: str,
+        checkin_id: str,
+        *,
+        mood: str,
+        note: str,
+        occurred_at: datetime,
+        logical_day: date,
+    ) -> MoodCheckIn:
+        data = self.store.data.users[user]
+        self._validate_mood_edit_day(logical_day, today=self._logical_today())
+        checkin = self._find_mood_checkin(data, checkin_id)
+        old_day = checkin.logical_date
+        checkin.logical_date = logical_day.isoformat()
+        checkin.mood = mood
+        checkin.note = note[:MAX_MOOD_NOTE_LENGTH]
+        checkin.occurred_at = occurred_at.astimezone(LOCAL_TIMEZONE).isoformat()
+        checkin.updated_at = datetime.now(UTC).isoformat()
+        checkin.__post_init__()
+        data.mood_narratives.pop(old_day, None)
+        data.mood_narratives.pop(checkin.logical_date, None)
+        self._finish_mood_mutation(user, "update", checkin)
+        if logical_day < self._logical_today():
+            self._generate_mood_narrative(user, logical_day)
+        return checkin
+
+    def _delete_mood_checkin(self, user: str, checkin_id: str) -> MoodCheckIn:
+        data = self.store.data.users[user]
+        checkin = self._find_mood_checkin(data, checkin_id)
+        checkin_day = date.fromisoformat(checkin.logical_date)
+        self._validate_mood_edit_day(checkin_day, today=self._logical_today())
+        data.mood_checkins.remove(checkin)
+        data.mood_narratives.pop(checkin.logical_date, None)
+        self._finish_mood_mutation(user, "delete", checkin)
+        if checkin_day < self._logical_today():
+            self._generate_mood_narrative(user, checkin_day)
+        return checkin
+
+    def _finish_mood_mutation(
+        self,
+        user: str,
+        operation: str,
+        checkin: MoodCheckIn,
+    ) -> None:
+        self.store.save()
+        self.store.append_mood_log(user, operation, checkin)
+        self._reset_mood_editor(user)
+        self._publish_mood_state(user)
+        self._publish_mood_editor_discovery()
+
+    def _update_mood_editor(  # noqa: C901
+        self,
+        user: str,
+        key: str,
+        payload: str,
+    ) -> None:
+        editor = self._mood_editor[user]
+        field = key.removeprefix("mood_edit_")
+        if field == "entry":
+            if payload != "New check-in" and payload not in self._mood_editor_ids[user]:
+                raise ValueError("unknown mood editor entry")
+            editor["entry"] = payload
+            if payload != "New check-in":
+                checkin = self._find_mood_checkin(
+                    self.store.data.users[user],
+                    self._mood_editor_ids[user][payload],
+                )
+                editor["date"] = checkin.logical_date
+                occurrence = (
+                    datetime.fromisoformat(checkin.occurred_at)
+                    if checkin.occurred_at is not None
+                    else datetime.combine(
+                        date.fromisoformat(checkin.logical_date),
+                        time(12),
+                        tzinfo=LOCAL_TIMEZONE,
+                    )
+                )
+                editor["time"] = occurrence.astimezone(LOCAL_TIMEZONE).strftime(
+                    "%H:%M:%S",
+                )
+                editor["value"] = checkin.mood
+                editor["note"] = checkin.note[:255]
+        elif field == "date":
+            selected = date.fromisoformat(payload)
+            self._validate_mood_edit_day(selected, today=self._logical_today())
+            editor["date"] = payload
+        elif field == "time":
+            time.fromisoformat(payload)
+            editor["time"] = payload
+        elif field == "value":
+            if payload not in MOOD_OPTIONS[1:]:
+                raise ValueError("invalid mood option")
+            editor["value"] = payload
+        elif field == "note":
+            editor["note"] = payload[:255]
+        elif field == "save":
+            self._save_mood_editor(user)
             return
-        data.mood_history.pop(today, None)
-        self._seed_mood_reminder(user, force=True)
+        elif field == "delete":
+            selected_id = self._selected_editor_id(user)
+            if selected_id is None:
+                raise ValueError("select an existing mood check-in before deleting")
+            self._delete_mood_checkin(user, selected_id)
+            return
+        else:
+            raise KeyError(key)
+        self._publish_mood_editor_state(user)
+
+    def _save_mood_editor(self, user: str) -> None:
+        editor = self._mood_editor[user]
+        logical_day = date.fromisoformat(editor["date"])
+        selected_time = time.fromisoformat(editor["time"])
+        calendar_day = (
+            logical_day + timedelta(days=1)
+            if selected_time.hour < LOGICAL_DAY_BOUNDARY_HOUR
+            else logical_day
+        )
+        occurrence = datetime.combine(
+            calendar_day,
+            selected_time,
+            tzinfo=LOCAL_TIMEZONE,
+        )
+        selected_id = self._selected_editor_id(user)
+        if selected_id is None:
+            self._create_mood_checkin(
+                user,
+                mood=editor["value"],
+                note=editor["note"],
+                source=(
+                    "dashboard" if logical_day == self._logical_today() else "backfill"
+                ),
+                occurred_at=occurrence,
+                logical_day=logical_day,
+            )
+            return
+        self._update_mood_checkin(
+            user,
+            selected_id,
+            mood=editor["value"],
+            note=editor["note"],
+            occurred_at=occurrence,
+            logical_day=logical_day,
+        )
+
+    def _selected_editor_id(self, user: str) -> str | None:
+        return self._mood_editor_ids[user].get(self._mood_editor[user]["entry"])
+
+    def _find_mood_checkin(self, data: UserData, checkin_id: str) -> MoodCheckIn:
+        for checkin in data.mood_checkins:
+            if checkin.id == checkin_id:
+                return checkin
+        raise ValueError("mood check-in not found")
+
+    def _validate_mood_edit_day(self, logical_day: date, *, today: date) -> None:
+        earliest = today - timedelta(days=MOOD_EDIT_WINDOW_DAYS - 1)
+        if not earliest <= logical_day <= today:
+            raise ValueError("mood check-in must be within the seven-day edit window")
+
+    @staticmethod
+    def _remember_mood_request(data: UserData, request_id: str | None) -> None:
+        if request_id is None:
+            return
+        data.mood_request_ids.append(request_id)
+        del data.mood_request_ids[:-MAX_MOOD_REQUEST_IDS]
 
     def _apply_mood_reminder_time(
         self,
@@ -532,16 +854,50 @@ class HabitTracker(hass.Hass):
             return
         data = self.store.data.users[user]
         prefix = self.mqtt.topic(f"{user}/mood")
-        self.mqtt.publish(f"{prefix}/mood_today/state", data.mood_today)
-        self.mqtt.publish(f"{prefix}/mood_note/state", data.mood_note)
+        today = self._logical_today()
+        streak = calculate_mood_streak(data.mood_checkins, today=today)
+        summaries = self._recent_mood_summaries(data, today=today, days=28)
+        current_summary = summarize_mood_day(data.mood_checkins, logical_day=today)
+        self.mqtt.publish(f"{prefix}/mood_today/state", "Not Set")
+        self.mqtt.publish(f"{prefix}/mood_note/state", data.mood_note_draft)
         self.mqtt.publish(
             f"{prefix}/mood_streak/state",
-            str(
-                calculate_mood_streak(
-                    data.mood_history,
-                    today=self.datetime().date(),
+            str(streak.current),
+        )
+        self.mqtt.publish(
+            f"{prefix}/mood_streak/attributes",
+            {
+                "longest_streak": streak.longest,
+                "completed_7_days": streak.completed_7,
+                "completed_28_days": streak.completed_28,
+                "consistency_7_days": streak.consistency_7,
+                "consistency_28_days": streak.consistency_28,
+                "logical_date": today.isoformat(),
+            },
+        )
+        self.mqtt.publish(
+            f"{prefix}/mood_summary/state",
+            "unknown" if current_summary is None else str(current_summary.average),
+        )
+        self.mqtt.publish(
+            f"{prefix}/mood_summary/attributes",
+            {
+                "logical_date": today.isoformat(),
+                "current": (
+                    None if current_summary is None else current_summary.to_dict()
                 ),
-            ),
+                "seven_days": summaries[-7:],
+                "daily_series": summaries,
+                "checkin_series": self._mood_chart_checkins(data, today=today),
+                "score_labels": {
+                    "1": "Very Low",
+                    "2": "Low",
+                    "3": "Okay",
+                    "4": "Good",
+                    "5": "Great",
+                },
+                "unit_of_measurement": "mood score",
+            },
         )
         self.mqtt.publish(f"{prefix}/mood_reminder_time/state", data.mood_reminder_time)
         self.mqtt.publish(
@@ -556,7 +912,148 @@ class HabitTracker(hass.Hass):
             f"{prefix}/mood_repeat_interval/state",
             str(data.mood_repeat_interval_minutes),
         )
+        self.mqtt.publish(
+            f"{prefix}/mood_context_prompts/state",
+            "ON" if data.mood_context_prompts_enabled else "OFF",
+        )
+        self.mqtt.publish(
+            f"{prefix}/mood_context_cooldown/state",
+            str(data.mood_context_cooldown_minutes),
+        )
+        self._publish_mood_editor_state(user)
         self._publish_mood_next_reminder(user)
+
+    def _recent_mood_summaries(
+        self,
+        data: UserData,
+        *,
+        today: date,
+        days: int,
+    ) -> list[dict[str, object]]:
+        values: list[dict[str, object]] = []
+        for offset in range(days - 1, -1, -1):
+            logical_day = today - timedelta(days=offset)
+            summary = summarize_mood_day(data.mood_checkins, logical_day=logical_day)
+            item: dict[str, object] = {
+                "logical_date": logical_day.isoformat(),
+                "timestamp": datetime.combine(
+                    logical_day,
+                    time(12),
+                    tzinfo=LOCAL_TIMEZONE,
+                ).isoformat(),
+            }
+            if summary is not None:
+                item.update(summary.to_dict())
+            else:
+                item.update({"average": None, "count": 0})
+            narrative = data.mood_narratives.get(logical_day.isoformat())
+            if narrative:
+                item["narrative"] = narrative
+            values.append(item)
+        return values
+
+    def _mood_chart_checkins(
+        self,
+        data: UserData,
+        *,
+        today: date,
+    ) -> list[dict[str, object]]:
+        earliest = today - timedelta(days=27)
+        values: list[dict[str, object]] = []
+        for checkin in data.mood_checkins:
+            logical_day = date.fromisoformat(checkin.logical_date)
+            if not earliest <= logical_day <= today:
+                continue
+            inferred = checkin.occurred_at is None
+            timestamp = (
+                datetime.combine(logical_day, time(12), tzinfo=LOCAL_TIMEZONE)
+                if inferred
+                else datetime.fromisoformat(cast("str", checkin.occurred_at))
+            )
+            values.append(
+                {
+                    "id": checkin.id,
+                    "timestamp": timestamp.isoformat(),
+                    "logical_date": checkin.logical_date,
+                    "score": checkin.score,
+                    "mood": checkin.mood,
+                    "inferred_time": inferred,
+                },
+            )
+        values.sort(key=lambda item: str(item["timestamp"]))
+        return values
+
+    def _editor_options(self, user: str) -> list[str]:
+        data = self.store.data.users[user]
+        earliest = self._logical_today() - timedelta(days=MOOD_EDIT_WINDOW_DAYS - 1)
+        mapping: dict[str, str] = {}
+        entries = sorted(
+            (
+                checkin
+                for checkin in data.mood_checkins
+                if date.fromisoformat(checkin.logical_date) >= earliest
+            ),
+            key=lambda checkin: (
+                checkin.occurred_at or checkin.logical_date,
+                checkin.created_at,
+            ),
+            reverse=True,
+        )
+        for checkin in entries:
+            clock = (
+                "time unknown"
+                if checkin.occurred_at is None
+                else datetime.fromisoformat(checkin.occurred_at)
+                .astimezone(LOCAL_TIMEZONE)
+                .strftime("%H:%M")
+            )
+            label = f"{checkin.logical_date} {clock} · {checkin.mood} · {checkin.id[:6]}"
+            mapping[label] = checkin.id
+        self._mood_editor_ids[user] = mapping
+        return ["New check-in", *mapping]
+
+    def _reset_mood_editor(self, user: str) -> None:
+        now = self._aware_now()
+        self._mood_editor[user].update(
+            {
+                "entry": "New check-in",
+                "date": logical_date_for(now).isoformat(),
+                "time": now.strftime("%H:%M:%S"),
+                "value": "Okay",
+                "note": "",
+            },
+        )
+
+    def _publish_mood_editor_state(self, user: str) -> None:
+        if self.mqtt is None:
+            return
+        editor = self._mood_editor[user]
+        prefix = self.mqtt.topic(f"{user}/mood")
+        for field, key in (
+            ("entry", "mood_edit_entry"),
+            ("date", "mood_edit_date"),
+            ("time", "mood_edit_time"),
+            ("value", "mood_edit_value"),
+            ("note", "mood_edit_note"),
+        ):
+            self.mqtt.publish(f"{prefix}/{key}/state", editor[field])
+
+    def _publish_mood_editor_discovery(self) -> None:
+        if self.mqtt is None:
+            return
+        self.mqtt.publish_mood_discovery(
+            self.users,
+            editor_options={user: self._editor_options(user) for user in self.users},
+        )
+        for user in self.users:
+            self._publish_mood_editor_state(user)
+
+    def _has_mood_for_day(self, data: UserData, logical_day: date) -> bool:
+        key = logical_day.isoformat()
+        return any(checkin.logical_date == key for checkin in data.mood_checkins)
+
+    def _logical_today(self) -> date:
+        return logical_date_for(self._aware_now())
 
     def _publish_habit_type_counts(self, user: str) -> None:
         if self.mqtt is None:
@@ -608,7 +1105,10 @@ class HabitTracker(hass.Hass):
         return changed
 
     def _restore_mood_reminder(self, user: str, data: UserData) -> bool:
-        if not data.mood_reminders_enabled or data.mood_today != "Not Set":
+        if not data.mood_reminders_enabled or self._has_mood_for_day(
+            data,
+            self._logical_today(),
+        ):
             if data.pending_mood_reminder is None:
                 return False
             self._clear_mood_pending(user)
@@ -657,7 +1157,7 @@ class HabitTracker(hass.Hass):
         if not data.mood_reminders_enabled:
             self._clear_mood_pending(user)
             return
-        if data.mood_today != "Not Set":
+        if self._has_mood_for_day(data, self._logical_today()):
             self._clear_mood_pending(user)
             return
         if not force and data.pending_mood_reminder is not None:
@@ -1251,14 +1751,14 @@ class HabitTracker(hass.Hass):
             self._clear_mood_pending(user)
             self.store.save()
             return
-        if data.mood_today != "Not Set":
+        if self._has_mood_for_day(data, self._logical_today()):
             self._clear_mood_pending(user)
             self.store.save()
             return
         now = self._aware_now()
         last_index = final_index or data.mood_repeat_count + 1
         next_index = reminder_index + 1
-        if next_index <= last_index and repeat_fits_before_midnight(
+        if next_index <= last_index and repeat_fits_before_logical_day_end(
             now,
             data.mood_repeat_interval_minutes,
         ):
@@ -1281,21 +1781,99 @@ class HabitTracker(hass.Hass):
 
     def _notify_mood(self, user: str, message: str) -> None:
         user_config = self._user_config(user)
+        request_id = uuid.uuid4().hex
+        action_groups = (
+            (
+                "low",
+                ("Very Low", "Low", "Okay"),
+            ),
+            (
+                "high",
+                ("Good", "Great"),
+            ),
+        )
+        streak = calculate_mood_streak(
+            self.store.data.users[user].mood_checkins,
+            today=self._logical_today(),
+        ).current
+        for suffix, moods in action_groups:
+            actions = [
+                {
+                    "action": (
+                        f"MOOD_CHECKIN__{user.upper()}__"
+                        f"{mood.upper().replace(' ', '_')}__{request_id}"
+                    ),
+                    "title": mood,
+                }
+                for mood in moods
+            ]
+            try:
+                self.call_service(
+                    "script/turn_on",
+                    entity_id=user_config["notify_script"],
+                    variables={
+                        "title": f"Mood · {streak}-day streak",
+                        "message": message,
+                        "notification_id": f"{user}_mood_{suffix}",
+                        "group": f"{user}_mood",
+                        "timeout": MOOD_NOTIFICATION_TIMEOUT_SECONDS,
+                        "mobile_notification_icon": "mdi:emoticon-outline",
+                        "url": user_config["dashboard_url"],
+                        "actions": json.dumps(actions),
+                    },
+                )
+            except Exception as error:
+                self.error(
+                    "Mood reminder notification failed for %s/%s: %s",
+                    user,
+                    suffix,
+                    error,
+                )
+
+    def _send_mood_note_prompt(self, user: str, checkin: MoodCheckIn) -> None:
+        user_config = self._user_config(user)
+        actions = [
+            {
+                "action": f"MOOD_NOTE__{user.upper()}__{checkin.id}",
+                "title": "Add a note",
+                "behavior": "textInput",
+            },
+            {
+                "action": f"MOOD_NOTE_SKIP__{user.upper()}__{checkin.id}",
+                "title": "Skip",
+            },
+        ]
         try:
             self.call_service(
                 "script/turn_on",
                 entity_id=user_config["notify_script"],
                 variables={
-                    "title": "Mood",
-                    "message": message,
-                    "notification_id": f"{user}_mood_reminder",
-                    "mobile_notification_icon": "mdi:emoticon-outline",
+                    "title": f"{checkin.mood} logged",
+                    "message": "Anything worth noting about how you feel?",
+                    "notification_id": f"{user}_mood_note_{checkin.id}",
+                    "group": f"{user}_mood",
+                    "timeout": MOOD_NOTE_TIMEOUT_SECONDS,
+                    "mobile_notification_icon": "mdi:note-edit-outline",
                     "url": user_config["dashboard_url"],
-                    "actions": "[]",
+                    "actions": json.dumps(actions),
                 },
             )
         except Exception as error:
-            self.error("Mood reminder notification failed for %s: %s", user, error)
+            self.error("Mood note notification failed for %s: %s", user, error)
+
+    def _clear_mood_notifications(self, user: str) -> None:
+        user_config = self._user_config(user)
+        for suffix in ("low", "high"):
+            with suppress(Exception):
+                self.call_service(
+                    "script/turn_on",
+                    entity_id=user_config["notify_script"],
+                    variables={
+                        "message": "clear_notification",
+                        "clear_notification": True,
+                        "notification_id": f"{user}_mood_{suffix}",
+                    },
+                )
 
     def _ai_message(self, user: str, config: HabitConfig) -> str | None:
         return self._generate_ai_message(
@@ -1312,6 +1890,54 @@ class HabitTracker(hass.Hass):
             context=self._ai_mood_context(user),
             kind="mood",
         )
+
+    def _generate_mood_narrative(self, user: str, logical_day: date) -> None:
+        data = self.store.data.users[user]
+        day_key = logical_day.isoformat()
+        entries = [
+            checkin for checkin in data.mood_checkins if checkin.logical_date == day_key
+        ]
+        notes = [checkin.note.strip() for checkin in entries if checkin.note.strip()]
+        summary = summarize_mood_day(data.mood_checkins, logical_day=logical_day)
+        if summary is None or not notes:
+            data.mood_narratives.pop(day_key, None)
+            self.store.save()
+            self._publish_mood_state(user)
+            return
+        try:
+            response = self.call_service(
+                "ai_task/generate_data",
+                service_data={
+                    "entity_id": self.args["ai_task_entity"],
+                    "task_name": f"mood daily summary {user} {day_key}",
+                    "instructions": (
+                        f"{MOOD_SUMMARY_INSTRUCTIONS}\n\n"
+                        f"Statistics: {json.dumps(summary.to_dict())}\n"
+                        f"Notes: {json.dumps(notes)}"
+                    ),
+                    "structure": {
+                        "summary": {
+                            "description": "One short plain-text sentence",
+                            "required": True,
+                            "selector": {"text": {"multiline": False}},
+                        },
+                    },
+                },
+                return_response=True,
+                hass_timeout=180,
+                timeout=180,
+            )
+        except Exception as error:
+            self.error("AI mood summary failed for %s/%s: %s", user, day_key, error)
+            return
+        generated = _ai_response_data(response)
+        narrative = generated.get("summary") if generated is not None else None
+        if not isinstance(narrative, str) or not narrative.strip():
+            self.error("AI mood summary returned no usable data for %s/%s", user, day_key)
+            return
+        data.mood_narratives[day_key] = narrative.strip()[:500]
+        self.store.save()
+        self._publish_mood_state(user)
 
     def _generate_ai_message(
         self,
@@ -1356,14 +1982,15 @@ class HabitTracker(hass.Hass):
             today=now.date(),
             min_days_per_week=config.streak_min_days_per_week,
         )
+        latest_mood = self._latest_mood_for_day(data, logical_date_for(now))
         pairs: list[tuple[str, object]] = [
             ("Habit name", config.name),
             ("Habit type", config.habit_type),
             ("Current streak days", stats.streak),
             ("Days since completion", stats.days_since_completion),
             ("28-day completion rate", stats.completion_rate_28_days),
-            ("Mood today", data.mood_today),
-            ("Mood note", data.mood_note),
+            ("Latest mood today", "" if latest_mood is None else latest_mood.mood),
+            ("Latest mood note", "" if latest_mood is None else latest_mood.note),
             ("Location category", self._location_category(user_config)),
             ("Calendar availability", self._calendar_availability(user, now)),
             (
@@ -1390,10 +2017,12 @@ class HabitTracker(hass.Hass):
         user_config = self._user_config(user)
         now = self._aware_now()
         pairs: list[tuple[str, object]] = [
-            ("Mood today", data.mood_today),
             (
                 "Mood streak days",
-                calculate_mood_streak(data.mood_history, today=now.date()),
+                calculate_mood_streak(
+                    data.mood_checkins,
+                    today=logical_date_for(now),
+                ).current,
             ),
             ("Location category", self._location_category(user_config)),
             ("Calendar availability", self._calendar_availability(user, now)),
@@ -1409,6 +2038,26 @@ class HabitTracker(hass.Hass):
             f"- {label}: {value}"
             for label, value in pairs
             if value not in INVALID_STATES and value not in {"Not Set", -1}
+        )
+
+    def _latest_mood_for_day(
+        self,
+        data: UserData,
+        logical_day: date,
+    ) -> MoodCheckIn | None:
+        entries = [
+            checkin
+            for checkin in data.mood_checkins
+            if checkin.logical_date == logical_day.isoformat()
+        ]
+        return max(
+            entries,
+            key=lambda checkin: (
+                checkin.occurred_at or "",
+                checkin.created_at,
+                checkin.id,
+            ),
+            default=None,
         )
 
     def _location_category(self, user_config: dict[str, Any]) -> str:
@@ -1442,6 +2091,394 @@ class HabitTracker(hass.Hass):
             if person_state not in INVALID_STATES
             else "unknown"
         )
+
+    def _restore_presence_context(self) -> None:
+        now = self._aware_now()
+        for user in self.users:
+            data = self.store.data.users[user]
+            person_state = self.get_state(str(self._user_config(user)["person_entity"]))
+            if person_state == "home":
+                data.mood_away_since = None
+                data.mood_away_saw_work = False
+            elif person_state not in INVALID_STATES and data.mood_away_since is None:
+                data.mood_away_since = now.isoformat()
+                data.mood_away_saw_work = (
+                    self.get_state(
+                        str(self._user_config(user)["at_work_entity"]),
+                    )
+                    == "on"
+                )
+
+    def _presence_changed(
+        self,
+        entity: str,
+        attribute: str,
+        old: object,
+        new: object,
+        **kwargs: Any,
+    ) -> None:
+        del entity, attribute
+        user = str(kwargs["user"])
+        data = self.store.data.users[user]
+        now = self._aware_now()
+        if new != "home":
+            if old == "home" or data.mood_away_since is None:
+                data.mood_away_since = now.isoformat()
+                data.mood_away_saw_work = (
+                    self.get_state(
+                        str(self._user_config(user)["at_work_entity"]),
+                    )
+                    == "on"
+                )
+                self.store.save()
+            return
+        if old == "home" or data.mood_away_since is None:
+            return
+        away_since = datetime.fromisoformat(data.mood_away_since)
+        duration_minutes = (now - away_since).total_seconds() / 60
+        reason: str | None = None
+        if data.mood_away_saw_work:
+            reason = "returning home from work"
+        elif duration_minutes >= CONTEXT_OUTING_MINUTES:
+            reason = "returning home after a substantial outing"
+        data.mood_away_since = None
+        data.mood_away_saw_work = False
+        self.store.save()
+        if reason is not None:
+            self.run_in(
+                self._return_home_prompt_callback,
+                CONTEXT_PROMPT_DELAY_MINUTES * 60,
+                user=user,
+                reason=reason,
+                occurred_at=now.isoformat(),
+            )
+
+    def _work_presence_changed(
+        self,
+        entity: str,
+        attribute: str,
+        old: object,
+        new: object,
+        **kwargs: Any,
+    ) -> None:
+        del entity, attribute, old
+        if new != "on":
+            return
+        user = str(kwargs["user"])
+        data = self.store.data.users[user]
+        if data.mood_away_since is not None:
+            data.mood_away_saw_work = True
+            self.store.save()
+
+    def _return_home_prompt_callback(self, kwargs: dict[str, Any]) -> None:
+        self._queue_context_prompt(
+            str(kwargs["user"]),
+            reason=str(kwargs["reason"]),
+            occurred_at=datetime.fromisoformat(str(kwargs["occurred_at"])),
+        )
+
+    def _scan_context_calendars(self, _kwargs: dict[str, Any]) -> None:
+        now = self._aware_now()
+        for user in self.users:
+            data = self.store.data.users[user]
+            if not data.mood_context_prompts_enabled:
+                continue
+            events = self._context_calendar_events(user, now=now)
+            for block in self._calendar_blocks(events, now=now):
+                fingerprint = self._calendar_block_fingerprint(user, block)
+                if fingerprint in self._calendar_scheduled:
+                    continue
+                decision = data.mood_calendar_decisions.get(fingerprint)
+                if decision is None:
+                    decision = self._classify_calendar_block(user, block, events)
+                    if len(data.mood_calendar_decisions) >= MAX_MOOD_CALENDAR_DECISIONS:
+                        oldest = next(iter(data.mood_calendar_decisions))
+                        data.mood_calendar_decisions.pop(oldest)
+                    data.mood_calendar_decisions[fingerprint] = decision
+                    self.store.save()
+                if not decision:
+                    continue
+                fire_at = cast("datetime", block["end"]) + timedelta(
+                    minutes=CONTEXT_PROMPT_DELAY_MINUTES,
+                )
+                if fire_at < now - timedelta(minutes=CONTEXT_STALE_MINUTES):
+                    continue
+                self._calendar_scheduled.add(fingerprint)
+                self.run_in(
+                    self._calendar_prompt_callback,
+                    max(0, (fire_at - now).total_seconds()),
+                    user=user,
+                    fingerprint=fingerprint,
+                    occurred_at=cast("datetime", block["end"]).isoformat(),
+                )
+
+    def _context_calendar_events(  # noqa: C901
+        self,
+        user: str,
+        *,
+        now: datetime,
+    ) -> list[dict[str, object]]:
+        calendar_labels = self._context_labels()["calendar"]
+        if not isinstance(calendar_labels, dict):
+            return []
+        label = calendar_labels.get(user)
+        entities = self._label_entities(label) if isinstance(label, str) else []
+        if not entities:
+            return []
+        try:
+            response = self.call_service(
+                "calendar/get_events",
+                entity_id=entities,
+                start_date_time=(now - timedelta(days=28)).isoformat(),
+                end_date_time=(now + timedelta(days=28)).isoformat(),
+                return_response=True,
+            )
+        except Exception as error:
+            self.error("Calendar mood context failed for %s: %s", user, error)
+            return []
+        payload = _service_result(response)
+        if payload is None:
+            return []
+        values: list[dict[str, object]] = []
+        for calendar_entity, calendar_payload in payload.items():
+            if not isinstance(calendar_payload, dict):
+                continue
+            raw_events = calendar_payload.get("events")
+            if not isinstance(raw_events, list):
+                continue
+            friendly_name = self.get_state(
+                str(calendar_entity),
+                attribute="friendly_name",
+            )
+            calendar_name = _privacy_safe_calendar_text(
+                friendly_name if isinstance(friendly_name, str) else "labelled calendar",
+                100,
+            )
+            for event in raw_events:
+                if not isinstance(event, dict):
+                    continue
+                if str(event.get("status", "")).lower() == "cancelled":
+                    continue
+                if _is_all_day_calendar_event(event):
+                    continue
+                start = _event_datetime(event.get("start"), now)
+                end = _event_datetime(event.get("end"), now)
+                if start is None or end is None or end <= start:
+                    continue
+                values.append(
+                    {
+                        "start": start,
+                        "end": end,
+                        "calendar": calendar_name,
+                        "summary": _privacy_safe_calendar_text(
+                            str(event.get("summary", "")),
+                            255,
+                        ),
+                        "description": _privacy_safe_calendar_text(
+                            str(event.get("description", "")),
+                            1000,
+                        ),
+                        "location": _privacy_safe_calendar_text(
+                            str(event.get("location", "")),
+                            255,
+                        ),
+                        "recurrence": (
+                            "recurring rule present"
+                            if event.get("rrule")
+                            else "recurrence instance"
+                            if event.get("recurrence_id")
+                            else "not recurring"
+                        ),
+                    },
+                )
+        return values
+
+    def _calendar_blocks(
+        self,
+        events: list[dict[str, object]],
+        *,
+        now: datetime,
+    ) -> list[dict[str, object]]:
+        relevant = sorted(
+            (
+                event
+                for event in events
+                if cast("datetime", event["end"]) >= now - timedelta(minutes=30)
+                and cast("datetime", event["start"]) <= now + timedelta(days=1)
+            ),
+            key=lambda event: cast("datetime", event["start"]),
+        )
+        blocks: list[dict[str, object]] = []
+        for event in relevant:
+            start = cast("datetime", event["start"])
+            end = cast("datetime", event["end"])
+            if not blocks or start > cast("datetime", blocks[-1]["end"]) + timedelta(
+                minutes=CALENDAR_BLOCK_GAP_MINUTES,
+            ):
+                blocks.append({"start": start, "end": end, "events": [event]})
+                continue
+            blocks[-1]["end"] = max(cast("datetime", blocks[-1]["end"]), end)
+            cast("list[dict[str, object]]", blocks[-1]["events"]).append(event)
+        return blocks
+
+    def _calendar_block_fingerprint(
+        self,
+        user: str,
+        block: dict[str, object],
+    ) -> str:
+        events = cast("list[dict[str, object]]", block["events"])
+        payload = {
+            "user": user,
+            "start": cast("datetime", block["start"]).isoformat(),
+            "end": cast("datetime", block["end"]).isoformat(),
+            "events": [
+                {
+                    "calendar": event["calendar"],
+                    "summary": event["summary"],
+                }
+                for event in events
+            ],
+        }
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode(),
+        ).hexdigest()
+
+    def _classify_calendar_block(
+        self,
+        user: str,
+        block: dict[str, object],
+        all_events: list[dict[str, object]],
+    ) -> bool:
+        block_events = cast("list[dict[str, object]]", block["events"])
+        normalized_summaries = [
+            _normalize_event_summary(str(event["summary"])) for event in all_events
+        ]
+        safe_events = []
+        for event in block_events:
+            normalized = _normalize_event_summary(str(event["summary"]))
+            safe_events.append(
+                {
+                    "title": event["summary"],
+                    "description": event["description"],
+                    "location": event["location"],
+                    "calendar": event["calendar"],
+                    "start": cast("datetime", event["start"]).isoformat(),
+                    "end": cast("datetime", event["end"]).isoformat(),
+                    "duration_minutes": round(
+                        (
+                            cast("datetime", event["end"])
+                            - cast("datetime", event["start"])
+                        ).total_seconds()
+                        / 60,
+                    ),
+                    "recurrence": event["recurrence"],
+                    "same_title_frequency_plus_minus_28_days": (
+                        normalized_summaries.count(normalized) if normalized else 0
+                    ),
+                },
+            )
+        try:
+            response = self.call_service(
+                "ai_task/generate_data",
+                service_data={
+                    "entity_id": self.args["ai_task_entity"],
+                    "task_name": f"mood event classifier {user}",
+                    "instructions": (
+                        f"{MOOD_EVENT_CLASSIFIER_INSTRUCTIONS}\n\n"
+                        f"Calendar block: {json.dumps(safe_events)}"
+                    ),
+                    "structure": {
+                        "prompt": {
+                            "description": "Whether to send a mood reflection prompt",
+                            "required": True,
+                            "selector": {"boolean": {}},
+                        },
+                        "reason": {
+                            "description": "A short internal category, not user-facing",
+                            "required": True,
+                            "selector": {"text": {"multiline": False}},
+                        },
+                    },
+                },
+                return_response=True,
+                hass_timeout=180,
+                timeout=180,
+            )
+        except Exception as error:
+            self.error("Mood calendar classifier failed closed for %s: %s", user, error)
+            return False
+        generated = _ai_response_data(response)
+        return generated is not None and generated.get("prompt") is True
+
+    def _calendar_prompt_callback(self, kwargs: dict[str, Any]) -> None:
+        fingerprint = str(kwargs["fingerprint"])
+        self._calendar_scheduled.discard(fingerprint)
+        self._queue_context_prompt(
+            str(kwargs["user"]),
+            reason="after a reflection-worthy calendar block",
+            occurred_at=datetime.fromisoformat(str(kwargs["occurred_at"])),
+        )
+
+    def _queue_context_prompt(
+        self,
+        user: str,
+        *,
+        reason: str,
+        occurred_at: datetime,
+    ) -> None:
+        data = self.store.data.users[user]
+        now = self._aware_now()
+        if (
+            not data.mood_context_prompts_enabled
+            or not self._has_mood_for_day(data, self._logical_today())
+            or now - occurred_at > timedelta(minutes=CONTEXT_STALE_MINUTES)
+        ):
+            return
+        last_prompt = (
+            None
+            if data.mood_last_context_prompt_at is None
+            else datetime.fromisoformat(data.mood_last_context_prompt_at).astimezone(
+                LOCAL_TIMEZONE,
+            )
+        )
+        cooldown = timedelta(minutes=data.mood_context_cooldown_minutes)
+        if last_prompt is None or now - last_prompt >= cooldown:
+            self._send_context_prompt(user)
+            return
+        self._pending_context[user] = {
+            "reason": reason,
+            "occurred_at": occurred_at.isoformat(),
+        }
+        if user in self._context_timers:
+            return
+        self._context_timers[user] = self.run_in(
+            self._context_prompt_callback,
+            max(0, (last_prompt + cooldown - now).total_seconds()),
+            user=user,
+        )
+
+    def _context_prompt_callback(self, kwargs: dict[str, Any]) -> None:
+        user = str(kwargs["user"])
+        self._context_timers.pop(user, None)
+        pending = self._pending_context.pop(user, None)
+        if pending is None:
+            return
+        occurred_at = datetime.fromisoformat(str(pending["occurred_at"]))
+        self._queue_context_prompt(
+            user,
+            reason=str(pending["reason"]),
+            occurred_at=occurred_at,
+        )
+
+    def _send_context_prompt(self, user: str) -> None:
+        self._notify_mood(
+            user,
+            "How are you feeling now? A quick check-in can capture how this part of your day landed.",
+        )
+        data = self.store.data.users[user]
+        data.mood_last_context_prompt_at = datetime.now(UTC).isoformat()
+        self.store.save()
+        self._publish_mood_state(user)
 
     def _calendar_availability(  # noqa: C901, PLR0911, PLR0912
         self,
@@ -1522,7 +2559,7 @@ class HabitTracker(hass.Hass):
             return f"Don't forget to mark {config.name} as complete!"
         return f"Don't forget to track {config.name}!"
 
-    def _handle_notification_action(
+    def _handle_notification_action(  # noqa: C901, PLR0911, PLR0912
         self,
         event_type: str,
         data: dict[str, Any],
@@ -1533,6 +2570,62 @@ class HabitTracker(hass.Hass):
         if not isinstance(action, str):
             return
         parts = action.split("__")
+        if (
+            action.startswith("MOOD_CHECKIN__")
+            and len(parts) == MOOD_CHECKIN_ACTION_PARTS
+        ):
+            _, user_upper, mood_slug, request_id = parts
+            user = user_upper.lower()
+            if user not in self.store.data.users:
+                return
+            try:
+                checkin = self._create_mood_checkin(
+                    user,
+                    mood=mood_slug.replace("_", " ").title(),
+                    note="",
+                    source="notification",
+                    request_id=request_id,
+                )
+            except (TypeError, ValueError) as error:
+                self.error("Rejected mood notification action %s: %s", action, error)
+                return
+            if checkin is not None:
+                self._send_mood_note_prompt(user, checkin)
+            return
+        if action.startswith("MOOD_NOTE__") and len(parts) == MOOD_NOTE_ACTION_PARTS:
+            _, user_upper, checkin_id = parts
+            user = user_upper.lower()
+            reply = data.get("reply_text", "")
+            if user not in self.store.data.users or not isinstance(reply, str):
+                return
+            try:
+                checkin = self._find_mood_checkin(
+                    self.store.data.users[user],
+                    checkin_id,
+                )
+                checkin.note = reply[:MAX_MOOD_NOTE_LENGTH]
+                checkin.updated_at = datetime.now(UTC).isoformat()
+                checkin.__post_init__()
+                self.store.data.users[user].mood_narratives.pop(
+                    checkin.logical_date,
+                    None,
+                )
+                self._finish_mood_mutation(user, "update", checkin)
+                if date.fromisoformat(checkin.logical_date) < self._logical_today():
+                    self._generate_mood_narrative(
+                        user,
+                        date.fromisoformat(checkin.logical_date),
+                    )
+                self._clear_notification(user, f"{user}_mood_note_{checkin.id}")
+            except ValueError as error:
+                self.error("Rejected mood note reply %s: %s", action, error)
+            return
+        if action.startswith("MOOD_NOTE_SKIP__") and len(parts) == MOOD_NOTE_ACTION_PARTS:
+            _, user_upper, checkin_id = parts
+            user = user_upper.lower()
+            if user in self.store.data.users:
+                self._clear_notification(user, f"{user}_mood_note_{checkin_id}")
+            return
         if len(parts) != ACTION_PARTS:
             return
         verb, user_upper, slot_raw = parts
@@ -1555,22 +2648,43 @@ class HabitTracker(hass.Hass):
         elif verb == "INCREMENT_HABIT" and config.habit_type is HabitType.COUNTABLE:
             self._set_completion(user, slot, current + 1)
 
+    def _handle_notification_cleared(
+        self,
+        event_type: str,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        del event_type, kwargs
+        tag = data.get("tag", data.get("notification_id"))
+        if not isinstance(tag, str):
+            return
+        for user in self.users:
+            if tag in {f"{user}_mood_low", f"{user}_mood_high"}:
+                sibling = "high" if tag.endswith("_low") else "low"
+                self._clear_notification(user, f"{user}_mood_{sibling}")
+                return
+
+    def _clear_notification(self, user: str, notification_id: str) -> None:
+        user_config = self._user_config(user)
+        with suppress(Exception):
+            self.call_service(
+                "script/turn_on",
+                entity_id=user_config["notify_script"],
+                variables={
+                    "message": "clear_notification",
+                    "clear_notification": True,
+                    "notification_id": notification_id,
+                },
+            )
+
     def _midnight_rollover(self, kwargs: dict[str, Any]) -> None:
         user = str(kwargs["user"])
         data = self.store.data.users[user]
-        today = self.datetime().date()
-        yesterday_key = (today - timedelta(days=1)).isoformat()
-        if data.mood_today != "Not Set":
-            data.mood_history[yesterday_key] = data.mood_today
-        data.mood_today = "Not Set"
-        data.mood_note = ""
         for slot in list(data.habits):
             self._clear_pending(user, slot)
-        self._clear_mood_pending(user)
         for config in data.habits.values():
             if config.configured:
                 self._seed_next_reminder(user, config, force=True)
-        self._seed_mood_reminder(user, force=True)
         # Progress records are keyed by day, so a stale one is replaced on the
         # next evaluation rather than cleared here.
         for slot, config in data.habits.items():
@@ -1578,10 +2692,22 @@ class HabitTracker(hass.Hass):
                 self.templates.cancel_duration(user, slot)
                 self._schedule_evaluation(user, slot)
         self.store.save()
-        self._publish_mood_state(user)
         for slot in data.habits:
             self._publish_habit_state(user, slot)
             self._publish_next_reminder(user, slot)
+
+    def _logical_day_rollover(self, kwargs: dict[str, Any]) -> None:
+        user = str(kwargs["user"])
+        data = self.store.data.users[user]
+        closed_day = self._logical_today() - timedelta(days=1)
+        self._clear_mood_pending(user)
+        data.mood_note_draft = ""
+        self._reset_mood_editor(user)
+        self._generate_mood_narrative(user, closed_day)
+        self._seed_mood_reminder(user, force=True)
+        self.store.save()
+        self._publish_mood_state(user)
+        self._publish_mood_editor_discovery()
 
     def _normalize_user_slots(
         self,
@@ -1731,6 +2857,22 @@ def _ai_response_text(response: object) -> str | None:
     return None
 
 
+def _ai_response_data(response: object) -> dict[str, Any] | None:
+    """Extract structured AI Task data from known HA/AppDaemon envelopes."""
+    payload = _service_result(response)
+    if payload is None:
+        return None
+    candidates: list[object] = [payload.get("data")]
+    for key in ("response", "service_response", "result"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            candidates.extend((nested.get("data"), nested))
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return {str(key): value for key, value in candidate.items()}
+    return None
+
+
 def _bounded_int(payload: str, minimum: int, maximum: int) -> int:
     value = int(float(payload))
     if not minimum <= value <= maximum:
@@ -1754,3 +2896,30 @@ def _event_datetime(value: object, now: datetime) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=now.tzinfo)
     return parsed.astimezone(now.tzinfo)
+
+
+def _is_all_day_calendar_event(event: dict[str, Any]) -> bool:
+    start = event.get("start")
+    end = event.get("end")
+    if isinstance(start, dict) and "date" in start:
+        return True
+    if isinstance(end, dict) and "date" in end:
+        return True
+    return isinstance(start, str) and "T" not in start
+
+
+def _normalize_event_summary(value: str) -> str:
+    return " ".join(
+        "".join(
+            character.lower() if character.isalnum() else " " for character in value
+        ).split(),
+    )
+
+
+def _privacy_safe_calendar_text(value: str, maximum: int) -> str:
+    """Remove contact details and opaque identifiers before AI classification."""
+    sanitized = CALENDAR_EMAIL_RE.sub("[contact removed]", value)
+    sanitized = CALENDAR_URL_RE.sub("[link removed]", sanitized)
+    sanitized = CALENDAR_PHONE_RE.sub("[contact removed]", sanitized)
+    sanitized = CALENDAR_OPAQUE_ID_RE.sub("[identifier removed]", sanitized)
+    return " ".join(sanitized.split())[:maximum]

--- a/apps/habit/models.py
+++ b/apps/habit/models.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from datetime import date, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final, Self
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-SCHEMA_VERSION: Final[int] = 2
+SCHEMA_VERSION: Final[int] = 3
 MIN_SCHEMA_VERSION: Final[int] = 1
 MAX_NAME_LENGTH: Final[int] = 255
 MAX_TEMPLATE_LENGTH: Final[int] = 255
@@ -27,6 +27,22 @@ MOOD_OPTIONS: Final[tuple[str, ...]] = (
     "Good",
     "Great",
 )
+MOOD_SCORES: Final[dict[str, int]] = {
+    mood: score for score, mood in enumerate(MOOD_OPTIONS[1:], start=1)
+}
+MOOD_SOURCES: Final[frozenset[str]] = frozenset(
+    {"dashboard", "notification", "backfill", "migration"},
+)
+MAX_MOOD_NOTE_LENGTH: Final[int] = 1024
+MAX_MOOD_DRAFT_LENGTH: Final[int] = 255
+MAX_MOOD_ID_LENGTH: Final[int] = 128
+LOGICAL_DAY_BOUNDARY_HOUR: Final[int] = 4
+MOOD_EDIT_WINDOW_DAYS: Final[int] = 7
+MAX_MOOD_REQUEST_IDS: Final[int] = 100
+MAX_MOOD_CALENDAR_DECISIONS: Final[int] = 512
+MIN_MOOD_CONTEXT_COOLDOWN: Final[int] = 15
+MAX_MOOD_CONTEXT_COOLDOWN: Final[int] = 360
+MIXED_MOOD_SCORE_RANGE: Final[int] = 2
 
 
 class UnsupportedSchemaVersionError(ValueError):
@@ -248,6 +264,89 @@ class TemplateProgress:
 
 
 @dataclass(slots=True)
+class MoodCheckIn:
+    """One immutable-identity mood observation."""
+
+    id: str
+    logical_date: str
+    mood: str
+    note: str = ""
+    source: str = "dashboard"
+    occurred_at: str | None = None
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def __post_init__(self) -> None:
+        """Reject malformed or ambiguous observations."""
+        if not self.id or len(self.id) > MAX_MOOD_ID_LENGTH:
+            raise ValueError("mood check-in id must be 1-128 characters")
+        date.fromisoformat(self.logical_date)
+        if self.mood not in MOOD_SCORES:
+            raise ValueError("invalid mood option")
+        if len(self.note) > MAX_MOOD_NOTE_LENGTH:
+            raise ValueError("mood note is too long")
+        if self.source not in MOOD_SOURCES:
+            raise ValueError("invalid mood source")
+        if self.occurred_at is not None:
+            datetime.fromisoformat(self.occurred_at)
+        datetime.fromisoformat(self.created_at)
+        datetime.fromisoformat(self.updated_at)
+
+    @property
+    def score(self) -> int:
+        """Return the stable numeric score for charts and aggregation."""
+        return MOOD_SCORES[self.mood]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize a check-in."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Self:
+        """Parse and validate a persisted check-in."""
+        return cls(
+            id=_string(value, "id"),
+            logical_date=_string(value, "logical_date"),
+            mood=_string(value, "mood"),
+            note=_string(value, "note", ""),
+            source=_string(value, "source", "dashboard"),
+            occurred_at=_optional_string(value, "occurred_at"),
+            created_at=_string(value, "created_at"),
+            updated_at=_string(value, "updated_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MoodDaySummary:
+    """Deterministic statistics for one logical day."""
+
+    logical_date: str
+    average: float
+    minimum: int
+    maximum: int
+    count: int
+    direction: str
+    mixed: bool
+    latest_mood: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize dashboard-safe summary data."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class MoodStreakStats:
+    """Current, longest, and recent mood consistency."""
+
+    current: int
+    longest: int
+    completed_7: int
+    completed_28: int
+    consistency_7: float
+    consistency_28: float
+
+
+@dataclass(slots=True)
 class UserData:
     """All disk-backed state for one configured user."""
 
@@ -255,11 +354,18 @@ class UserData:
     completions: dict[int, dict[str, int]] = field(default_factory=dict)
     pending_reminders: dict[int, PendingReminder] = field(default_factory=dict)
     template_progress: dict[int, TemplateProgress] = field(default_factory=dict)
-    mood_history: dict[str, str] = field(default_factory=dict)
-    mood_today: str = "Not Set"
-    mood_note: str = ""
+    mood_checkins: list[MoodCheckIn] = field(default_factory=list)
+    mood_note_draft: str = ""
+    mood_narratives: dict[str, str] = field(default_factory=dict)
+    mood_request_ids: list[str] = field(default_factory=list)
+    mood_context_prompts_enabled: bool | None = None
+    mood_context_cooldown_minutes: int = 90
+    mood_last_context_prompt_at: str | None = None
+    mood_calendar_decisions: dict[str, bool] = field(default_factory=dict)
+    mood_away_since: str | None = None
+    mood_away_saw_work: bool = False
     mood_reminder_time: str = "20:00:00"
-    mood_reminders_enabled: bool = True
+    mood_reminders_enabled: bool | None = None
     mood_repeat_count: int = 0
     mood_repeat_interval_minutes: int = 60
     pending_mood_reminder: PendingReminder | None = None
@@ -276,6 +382,22 @@ class UserData:
             time.fromisoformat(self.mood_reminder_time)
         except ValueError as error:
             raise ValueError("mood_reminder_time must use HH:MM:SS") from error
+        if len(self.mood_note_draft) > MAX_MOOD_DRAFT_LENGTH:
+            raise ValueError("mood note draft is too long")
+        if not (
+            MIN_MOOD_CONTEXT_COOLDOWN
+            <= self.mood_context_cooldown_minutes
+            <= MAX_MOOD_CONTEXT_COOLDOWN
+        ):
+            raise ValueError("mood context cooldown must be between 15 and 360")
+        if len(self.mood_request_ids) > MAX_MOOD_REQUEST_IDS:
+            raise ValueError("too many retained mood request ids")
+        if len(self.mood_calendar_decisions) > MAX_MOOD_CALENDAR_DECISIONS:
+            raise ValueError("too many cached mood calendar decisions")
+        if self.mood_last_context_prompt_at is not None:
+            datetime.fromisoformat(self.mood_last_context_prompt_at)
+        if self.mood_away_since is not None:
+            datetime.fromisoformat(self.mood_away_since)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize user data."""
@@ -294,9 +416,16 @@ class UserData:
                 str(slot): progress.to_dict()
                 for slot, progress in self.template_progress.items()
             },
-            "mood_history": self.mood_history,
-            "mood_today": self.mood_today,
-            "mood_note": self.mood_note,
+            "mood_checkins": [checkin.to_dict() for checkin in self.mood_checkins],
+            "mood_note_draft": self.mood_note_draft,
+            "mood_narratives": self.mood_narratives,
+            "mood_request_ids": self.mood_request_ids,
+            "mood_context_prompts_enabled": self.mood_context_prompts_enabled,
+            "mood_context_cooldown_minutes": self.mood_context_cooldown_minutes,
+            "mood_last_context_prompt_at": self.mood_last_context_prompt_at,
+            "mood_calendar_decisions": self.mood_calendar_decisions,
+            "mood_away_since": self.mood_away_since,
+            "mood_away_saw_work": self.mood_away_saw_work,
             "mood_reminder_time": self.mood_reminder_time,
             "mood_reminders_enabled": self.mood_reminders_enabled,
             "mood_repeat_count": self.mood_repeat_count,
@@ -331,30 +460,64 @@ class UserData:
             int(slot): TemplateProgress.from_dict(_dict(item))
             for slot, item in _mapping(value, "template_progress").items()
         }
-        mood_history = {
-            _date_string(day): _mood(mood)
-            for day, mood in _mapping(value, "mood_history").items()
+        raw_checkins = value.get("mood_checkins", [])
+        if not isinstance(raw_checkins, list):
+            raise TypeError("mood_checkins must be a list")
+        mood_checkins = [MoodCheckIn.from_dict(_dict(item)) for item in raw_checkins]
+        mood_narratives = {
+            _date_string(day): str(narrative)
+            for day, narrative in _mapping(value, "mood_narratives").items()
         }
+        raw_request_ids = value.get("mood_request_ids", [])
+        if not isinstance(raw_request_ids, list) or not all(
+            isinstance(item, str) for item in raw_request_ids
+        ):
+            raise TypeError("mood_request_ids must be a string list")
         raw_pending_mood = value.get("pending_mood_reminder")
         pending_mood = (
             None
             if raw_pending_mood in (None, {})
             else PendingReminder.from_dict(_dict(raw_pending_mood))
         )
+        raw_calendar_decisions = _mapping(value, "mood_calendar_decisions")
+        if not all(
+            isinstance(decision, bool) for decision in raw_calendar_decisions.values()
+        ):
+            raise TypeError("mood_calendar_decisions values must be booleans")
         return cls(
             habits=habits,
             completions=completions,
             pending_reminders=pending_reminders,
             template_progress=template_progress,
-            mood_history=mood_history,
-            mood_today=_mood(value.get("mood_today", "Not Set")),
-            mood_note=_string(value, "mood_note", ""),
-            mood_reminder_time=_string(value, "mood_reminder_time", "20:00:00"),
-            mood_reminders_enabled=_boolean(
+            mood_checkins=mood_checkins,
+            mood_note_draft=_string(value, "mood_note_draft", ""),
+            mood_narratives=mood_narratives,
+            mood_request_ids=list(raw_request_ids),
+            mood_context_prompts_enabled=_optional_boolean(
                 value,
-                "mood_reminders_enabled",
-                default=True,
+                "mood_context_prompts_enabled",
             ),
+            mood_context_cooldown_minutes=_integer(
+                value,
+                "mood_context_cooldown_minutes",
+                90,
+            ),
+            mood_last_context_prompt_at=_optional_string(
+                value,
+                "mood_last_context_prompt_at",
+            ),
+            mood_calendar_decisions={
+                str(fingerprint): decision
+                for fingerprint, decision in raw_calendar_decisions.items()
+            },
+            mood_away_since=_optional_string(value, "mood_away_since"),
+            mood_away_saw_work=_boolean(
+                value,
+                "mood_away_saw_work",
+                default=False,
+            ),
+            mood_reminder_time=_string(value, "mood_reminder_time", "20:00:00"),
+            mood_reminders_enabled=_optional_boolean(value, "mood_reminders_enabled"),
             mood_repeat_count=_integer(value, "mood_repeat_count", 0),
             mood_repeat_interval_minutes=_integer(
                 value,
@@ -374,11 +537,82 @@ def _migrate_1_to_2(value: dict[str, Any]) -> dict[str, Any]:
     return value
 
 
+def _migrate_2_to_3(value: dict[str, Any]) -> dict[str, Any]:
+    """Convert one-value-per-day mood history to timestamped check-ins."""
+    migrated = dict(value)
+    users = _mapping(migrated, "users")
+    migrated_users: dict[str, Any] = {}
+    migration_time = datetime.now(UTC).isoformat()
+    local_today = datetime.now().astimezone().date().isoformat()
+    for user, raw_user in users.items():
+        user_data = _dict(raw_user)
+        history = _mapping(user_data, "mood_history")
+        current_mood = user_data.get("mood_today", "Not Set")
+        current_note = user_data.get("mood_note", "")
+        checkins: list[dict[str, object]] = []
+        for day, mood in sorted(history.items()):
+            _date_string(day)
+            validated_mood = _mood(mood)
+            if validated_mood == "Not Set":
+                continue
+            checkins.append(
+                {
+                    "id": f"legacy-{user}-{day}",
+                    "logical_date": day,
+                    "mood": validated_mood,
+                    "note": (
+                        str(current_note)[:MAX_MOOD_NOTE_LENGTH]
+                        if day == local_today and validated_mood == current_mood
+                        else ""
+                    ),
+                    "source": "migration",
+                    "occurred_at": None,
+                    "created_at": migration_time,
+                    "updated_at": migration_time,
+                },
+            )
+        if current_mood in MOOD_SCORES and not any(
+            item["logical_date"] == local_today for item in checkins
+        ):
+            checkins.append(
+                {
+                    "id": f"legacy-{user}-{local_today}",
+                    "logical_date": local_today,
+                    "mood": str(current_mood),
+                    "note": str(current_note)[:MAX_MOOD_NOTE_LENGTH],
+                    "source": "migration",
+                    "occurred_at": None,
+                    "created_at": migration_time,
+                    "updated_at": migration_time,
+                },
+            )
+        for legacy_key in ("mood_history", "mood_today", "mood_note"):
+            user_data.pop(legacy_key, None)
+        user_data.update(
+            {
+                "mood_checkins": checkins,
+                "mood_note_draft": "",
+                "mood_narratives": {},
+                "mood_request_ids": [],
+                "mood_context_prompts_enabled": None,
+                "mood_context_cooldown_minutes": 90,
+                "mood_last_context_prompt_at": None,
+                "mood_calendar_decisions": {},
+                "mood_away_since": None,
+                "mood_away_saw_work": False,
+            },
+        )
+        migrated_users[user] = user_data
+    migrated["users"] = migrated_users
+    return migrated
+
+
 # Upgrade steps keyed by source version; entry N migrates a payload from
 # version N to version N+1. Register a step in the same change that bumps
 # SCHEMA_VERSION.
 SCHEMA_MIGRATIONS: Final[dict[int, Callable[[dict[str, Any]], dict[str, Any]]]] = {
     1: _migrate_1_to_2,
+    2: _migrate_2_to_3,
 }
 
 
@@ -480,14 +714,72 @@ def calculate_streak(
     return StreakStats(streak, days_since, round(completed_28 / 28 * 100, 1))
 
 
-def calculate_mood_streak(mood_history: dict[str, str], *, today: date) -> int:
-    """Count consecutive completed mood entries ending yesterday."""
-    streak = 0
-    checked = today - timedelta(days=1)
-    while mood_history.get(checked.isoformat()) in MOOD_OPTIONS[1:]:
-        streak += 1
-        checked -= timedelta(days=1)
-    return streak
+def logical_date_for(value: datetime) -> date:
+    """Map local timestamps before 04:00 onto the preceding logical day."""
+    return (value - timedelta(hours=LOGICAL_DAY_BOUNDARY_HOUR)).date()
+
+
+def summarize_mood_day(
+    checkins: list[MoodCheckIn],
+    *,
+    logical_day: date,
+) -> MoodDaySummary | None:
+    """Aggregate every check-in belonging to one logical day."""
+    entries = [item for item in checkins if item.logical_date == logical_day.isoformat()]
+    if not entries:
+        return None
+    entries.sort(key=_mood_checkin_sort_key)
+    scores = [item.score for item in entries]
+    first_score = scores[0]
+    latest_score = scores[-1]
+    return MoodDaySummary(
+        logical_date=logical_day.isoformat(),
+        average=round(sum(scores) / len(scores), 2),
+        minimum=min(scores),
+        maximum=max(scores),
+        count=len(scores),
+        direction=(
+            "up"
+            if latest_score > first_score
+            else "down"
+            if latest_score < first_score
+            else "steady"
+        ),
+        mixed=max(scores) - min(scores) >= MIXED_MOOD_SCORE_RANGE,
+        latest_mood=entries[-1].mood,
+    )
+
+
+def calculate_mood_streak(
+    checkins: list[MoodCheckIn],
+    *,
+    today: date,
+) -> MoodStreakStats:
+    """Calculate immediate and historical logical-day consistency."""
+    completed = {date.fromisoformat(item.logical_date) for item in checkins}
+    anchor = today if today in completed else today - timedelta(days=1)
+    current = _strict_daily_streak(completed, anchor)
+    longest = 0
+    running = 0
+    previous: date | None = None
+    for completed_day in sorted(completed):
+        running = running + 1 if previous == completed_day - timedelta(days=1) else 1
+        longest = max(longest, running)
+        previous = completed_day
+    completed_7 = sum(today - timedelta(days=6) <= day <= today for day in completed)
+    completed_28 = sum(today - timedelta(days=27) <= day <= today for day in completed)
+    return MoodStreakStats(
+        current=current,
+        longest=longest,
+        completed_7=completed_7,
+        completed_28=completed_28,
+        consistency_7=round(completed_7 / 7 * 100, 1),
+        consistency_28=round(completed_28 / 28 * 100, 1),
+    )
+
+
+def _mood_checkin_sort_key(checkin: MoodCheckIn) -> tuple[str, str, str]:
+    return (checkin.occurred_at or "", checkin.created_at, checkin.id)
 
 
 def normalize_spare_slot(data: UserData) -> tuple[int | None, tuple[int, ...]]:
@@ -609,6 +901,15 @@ def _boolean(value: dict[str, Any], key: str, *, default: bool) -> bool:
     item = value.get(key, default)
     if not isinstance(item, bool):
         raise TypeError(f"{key} must be a boolean")
+    return item
+
+
+def _optional_boolean(value: dict[str, Any], key: str) -> bool | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, bool):
+        raise TypeError(f"{key} must be a boolean or null")
     return item
 
 

--- a/apps/habit/mqtt.py
+++ b/apps/habit/mqtt.py
@@ -248,7 +248,12 @@ class HabitMqtt:
                 "",
             )
 
-    def publish_mood_discovery(self, users: Iterable[str]) -> None:
+    def publish_mood_discovery(
+        self,
+        users: Iterable[str],
+        *,
+        editor_options: dict[str, list[str]] | None = None,
+    ) -> None:
         """Publish user-level mood and habit-count entities."""
         for user in users:
             display = user.title()
@@ -265,6 +270,13 @@ class HabitMqtt:
                     "mood_streak",
                     "Mood streak",
                     {"unit_of_measurement": "days", "icon": "mdi:fire"},
+                    configurable=False,
+                ),
+                EntitySpec(
+                    "sensor",
+                    "mood_summary",
+                    "Mood summary",
+                    {"icon": "mdi:chart-timeline-variant"},
                     configurable=False,
                 ),
                 EntitySpec(
@@ -305,6 +317,72 @@ class HabitMqtt:
                     },
                 ),
                 EntitySpec(
+                    "switch",
+                    "mood_context_prompts",
+                    "Mood contextual prompts",
+                    {},
+                ),
+                EntitySpec(
+                    "number",
+                    "mood_context_cooldown",
+                    "Mood contextual cooldown",
+                    {
+                        "min": 15,
+                        "max": 360,
+                        "step": 15,
+                        "mode": "slider",
+                        "unit_of_measurement": "min",
+                    },
+                ),
+                EntitySpec(
+                    "select",
+                    "mood_edit_entry",
+                    "Mood editor entry",
+                    {
+                        "options": (editor_options or {}).get(
+                            user,
+                            ["New check-in"],
+                        ),
+                        "icon": "mdi:history",
+                    },
+                ),
+                EntitySpec(
+                    "date",
+                    "mood_edit_date",
+                    "Mood editor date",
+                    {"icon": "mdi:calendar-edit"},
+                ),
+                EntitySpec(
+                    "time",
+                    "mood_edit_time",
+                    "Mood editor time",
+                    {"icon": "mdi:clock-edit-outline"},
+                ),
+                EntitySpec(
+                    "select",
+                    "mood_edit_value",
+                    "Mood editor value",
+                    {"options": list(MOOD_OPTIONS[1:])},
+                ),
+                EntitySpec(
+                    "text",
+                    "mood_edit_note",
+                    "Mood editor note",
+                    {"max": 255, "icon": "mdi:note-edit-outline"},
+                ),
+                EntitySpec(
+                    "button",
+                    "mood_edit_save",
+                    "Mood editor save",
+                    {"icon": "mdi:content-save"},
+                ),
+                EntitySpec(
+                    "button",
+                    "mood_edit_delete",
+                    "Mood editor delete",
+                    {"icon": "mdi:delete-outline"},
+                ),
+                EntitySpec(
                     "sensor",
                     "habits_binary_count",
                     f"{display} | Habits Binary Count",
@@ -329,7 +407,6 @@ class HabitMqtt:
                     "name": spec.name,
                     "unique_id": f"appdaemon_{object_id}",
                     "default_entity_id": f"{spec.component}.{object_id}",
-                    "state_topic": self.topic(f"{state_path}/state"),
                     "availability_topic": self.topic("availability"),
                     "payload_available": "online",
                     "payload_not_available": "offline",
@@ -337,12 +414,18 @@ class HabitMqtt:
                     "origin": self._origin(),
                     **spec.extra,
                 }
+                if spec.component != "button":
+                    payload["state_topic"] = self.topic(f"{state_path}/state")
                 if spec.component != "sensor":
                     payload["command_topic"] = self.topic(f"{state_path}/set")
                 if spec.component == "switch":
                     payload.update({"payload_on": "ON", "payload_off": "OFF"})
                 if spec.configurable:
                     payload["entity_category"] = "config"
+                if spec.key in {"mood_streak", "mood_summary"}:
+                    payload["json_attributes_topic"] = self.topic(
+                        f"{state_path}/attributes",
+                    )
                 self.publish(self._config_topic(spec.component, object_id), payload)
 
     def subscribe_commands(self) -> None:

--- a/apps/habit/reminders.py
+++ b/apps/habit/reminders.py
@@ -134,3 +134,17 @@ def repeat_fits_before_midnight(now: datetime, interval_minutes: int) -> bool:
     )
     cutoff = next_midnight - timedelta(minutes=interval_minutes + 5)
     return now < cutoff
+
+
+def repeat_fits_before_logical_day_end(
+    now: datetime,
+    interval_minutes: int,
+    *,
+    boundary_hour: int = 4,
+) -> bool:
+    """Return whether a repeat fits before the next logical-day boundary."""
+    boundary = datetime.combine(now.date(), time(boundary_hour), tzinfo=now.tzinfo)
+    if now >= boundary:
+        boundary += timedelta(days=1)
+    cutoff = boundary - timedelta(minutes=interval_minutes + 5)
+    return now < cutoff

--- a/apps/habit/store.py
+++ b/apps/habit/store.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from .models import StoreData, UnsupportedSchemaVersionError
+from .models import SCHEMA_VERSION, MoodCheckIn, StoreData, UnsupportedSchemaVersionError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -64,6 +64,7 @@ class HabitStore:
                 )
                 self._quarantine(candidate)
             else:
+                self._preserve_pre_migration(candidate)
                 for user in self.users:
                     data.users.setdefault(user, StoreData.empty((user,)).users[user])
                 return data
@@ -76,6 +77,22 @@ class HabitStore:
         else:
             self._log("No habit store found; starting with an empty store")
         return StoreData.empty(self.users)
+
+    def _preserve_pre_migration(self, path: Path) -> None:
+        """Keep one immutable copy of a valid older schema before first save."""
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            version = payload.get("schema_version") if isinstance(payload, dict) else None
+            if not isinstance(version, int) or version >= SCHEMA_VERSION:
+                return
+            destination = self.directory / f"store.json.schema-v{version}-backup"
+            if destination.exists():
+                return
+            shutil.copy2(path, destination)
+            destination.chmod(0o600)
+            self._log(f"Preserved pre-migration habit store at {destination}")
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._error(f"Could not preserve pre-migration habit store: {exc}")
 
     @staticmethod
     def _read(path: Path) -> StoreData:
@@ -137,6 +154,22 @@ class HabitStore:
             "count": count,
         }
         path = self.directory / "completions.jsonl"
+        with path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(record, sort_keys=True))
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        path.chmod(0o600)
+
+    def append_mood_log(self, user: str, operation: str, checkin: MoodCheckIn) -> None:
+        """Append an audit record after a mood mutation."""
+        record: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "user": user,
+            "operation": operation,
+            "checkin": checkin.to_dict(),
+        }
+        path = self.directory / "mood-checkins.jsonl"
         with path.open("a", encoding="utf-8") as file:
             file.write(json.dumps(record, sort_keys=True))
             file.write("\n")


### PR DESCRIPTION


---



- 9816993 | feat: enhance mood tracking with new features

<!-- pr-review:summary:start -->
## Review Summary

Replaces the single "mood of the day" value with a timestamped `MoodCheckIn` history (schema v2→v3, with a preserved one-time pre-migration backup), a 04:00 logical-day boundary, a seven-day dashboard editor for backfilling entries, richer 7/28-day streak and summary statistics with optional AI-generated daily narratives, and a new context-aware prompting system: presence-based "welcome home" prompts and AI-classified calendar-block prompts, both gated by per-user opt-in and a configurable cooldown.

```mermaid
flowchart TD
    A[Mood trigger] -->|dashboard select| B[_create_mood_checkin]
    A -->|notification action| B
    A -->|editor save| B
    B --> C[Validate: mood, edit window, dedup request id]
    C --> D[Append MoodCheckIn to store]
    D --> E[Clear pending reminder if first check-in today]
    D --> F[Recompute streak / 7d & 28d summaries]
    D -->|past day| G[Regenerate AI narrative]
    H[Presence / calendar events] --> I[_queue_context_prompt]
    I -->|cooldown elapsed| J[Send context prompt]
    I -->|within cooldown| K[Coalesce, schedule for cooldown end]
```

Traced the full lifecycle end-to-end (check-in create/edit/delete, notification round-trip, logical-day rollover, migration, context-prompt cooldown/coalescing) — no blocking correctness issues found. Posted as a Comment-verdict review: MQTT discovery is republished for all users on every single mood mutation rather than just the affected user, calendar event text sent to the AI classifier has only partial PII redaction, and the in-memory calendar-prompt dedup set isn't restart-safe. Auto-merge was disabled before posting given the non-approve verdict.
<!-- pr-review:summary:end -->