### PR TITLE
fix: restart errored torrents after storage cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,27 @@
 ## qBittorrent Storage Cleanup
 
 `apps/qbittorrent/storage_cleanup.py` watches the qBittorrent scratch-storage
-sensor. When usage crosses 99.9%, it asks qBittorrent for the completed torrents
-currently seeding and ranks them by the nearer of their effective ratio and seeding
-time limits. The notification identifies the nearest candidate by name, size, and
-ratio and includes an action to delete that exact torrent and its content.
+sensor. When usage crosses the threshold configured in Home Assistant, it asks
+qBittorrent for the completed torrents currently seeding and ranks them by the nearer
+of their effective ratio and seeding time limits. The notification identifies the
+nearest candidate by name, size, and ratio and includes an action to delete that exact
+torrent and its content.
 Torrents currently transferring upload data are skipped, and this is checked again
 when the notification action is pressed.
 
 After a confirmed deletion, the app waits 90 seconds for the storage sensor to
 refresh. It then re-arms the threshold and offers the next eligible torrent only if
-usage is still at or above 99.9%, with a separate confirmation required each time.
-Once usage falls below the threshold, the app finds torrents in qBittorrent's
-`errored` filter and starts them again. This recovers downloads that stopped when
-the scratch disk ran out of space; qBittorrent 4's `resume` and qBittorrent 5's
-`start` Web API operations are both supported.
+usage is still at or above the configured threshold, with a separate confirmation
+required each time.
+Errored torrents are only started again once usage falls below `reset_below`
+(99.0% by default), so a deletion that barely dips under the threshold does not
+immediately refill the disk. qBittorrent 4's `resume` and qBittorrent 5's `start`
+Web API operations are both supported.
+
+The cleanup threshold is read from
+`input_number.qbittorrent_storage_cleanup_threshold` and changes take effect without
+reloading AppDaemon. The `threshold` value in `apps/apps.yaml` remains the fallback
+while the helper is unavailable.
 
 Ratio progress has a configurable `1.25` weighting when candidates are ordered. A
 torrent at ratio `4 / 5` therefore ranks alongside one at its full seeding-time limit,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ when the notification action is pressed.
 After a confirmed deletion, the app waits 90 seconds for the storage sensor to
 refresh. It then re-arms the threshold and offers the next eligible torrent only if
 usage is still at or above 99.9%, with a separate confirmation required each time.
+Once usage falls below the threshold, the app finds torrents in qBittorrent's
+`errored` filter and starts them again. This recovers downloads that stopped when
+the scratch disk ran out of space; qBittorrent 4's `resume` and qBittorrent 5's
+`start` Web API operations are both supported.
 
 Ratio progress has a configurable `1.25` weighting when candidates are ordered. A
 torrent at ratio `4 / 5` therefore ranks alongside one at its full seeding-time limit,
@@ -31,8 +35,8 @@ qbittorrent_username: <Web-UI-username>
 qbittorrent_password: <Web-UI-password>
 ```
 
-The configured qBittorrent user must be allowed to list torrents and delete torrent
-content. No additional Python runtime dependency is required.
+The configured qBittorrent user must be allowed to list, start, and delete torrents
+and their content. No additional Python runtime dependency is required.
 
 ## Student Loan (SLC)
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,10 @@ Torrents currently transferring upload data are skipped, and this is checked aga
 when the notification action is pressed.
 
 After a confirmed deletion, the app waits 90 seconds for the storage sensor to
-refresh. It then re-arms the threshold and offers the next eligible torrent only if
+refresh. It then restarts errored torrents and offers the next eligible torrent if
 usage is still at or above the configured threshold, with a separate confirmation
-required each time.
-Errored torrents are only started again once usage falls below `reset_below`
-(99.0% by default), so a deletion that barely dips under the threshold does not
-immediately refill the disk. qBittorrent 4's `resume` and qBittorrent 5's `start`
-Web API operations are both supported.
+required each time. qBittorrent 4's `resume` and qBittorrent 5's `start` Web API
+operations are both supported.
 
 The cleanup threshold is read from
 `input_number.qbittorrent_storage_cleanup_threshold` and changes take effect without

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ when the notification action is pressed.
 After a confirmed deletion, the app waits 90 seconds for the storage sensor to
 refresh. It then restarts errored torrents and offers the next eligible torrent if
 usage is still at or above the configured threshold, with a separate confirmation
-required each time. qBittorrent 4's `resume` and qBittorrent 5's `start` Web API
-operations are both supported.
+required each time.
 
 The cleanup threshold is read from
 `input_number.qbittorrent_storage_cleanup_threshold` and changes take effect without

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -42,6 +42,7 @@ qbittorrent_storage_cleanup:
   module: storage_cleanup
   class: QbittorrentStorageCleanup
   storage_entity: sensor.storage_cc_scratch_qbt_disk_used_percentage
+  threshold_entity: input_number.qbittorrent_storage_cleanup_threshold
   threshold: 99.9
   reset_below: 99.0
   post_delete_check_delay: 90

--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -44,7 +44,7 @@ qbittorrent_storage_cleanup:
   storage_entity: sensor.storage_cc_scratch_qbt_disk_used_percentage
   threshold_entity: input_number.qbittorrent_storage_cleanup_threshold
   threshold: 99.9
-  reset_below: 99.0
+  reset_below: 98.0
   post_delete_check_delay: 90
   ratio_progress_weight: 1.25  # Makes ratio 4/5 tie with time 28/28 days.
   request_timeout: 15

--- a/apps/qbittorrent/storage_cleanup.py
+++ b/apps/qbittorrent/storage_cleanup.py
@@ -11,7 +11,6 @@ from requests import RequestException, Response, Session
 
 BYTES_PER_UNIT: Final = 1024
 SECONDS_PER_MINUTE: Final = 60
-QBITTORRENT_START_API_MAJOR: Final = 5
 USE_GLOBAL_LIMIT: Final = -2.0
 ACTION_PREFIX: Final = "DELETE_QBT_TORRENT_"
 TORRENT_HASH_PATTERN: Final = compile_regex(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
@@ -116,11 +115,6 @@ class QbittorrentWebApi:
     def restart_errored(self) -> list[str]:
         """Start torrents currently reported in qBittorrent's errored filter."""
         with self._authenticated_session() as session:
-            version = self._request(
-                session,
-                "GET",
-                "/api/v2/app/version",
-            ).text.strip()
             torrents = self._json_list(
                 self._request(
                     session,
@@ -140,15 +134,10 @@ class QbittorrentWebApi:
                 return []
 
             hashes = "|".join(str(torrent["hash"]).lower() for torrent in errored)
-            endpoint = (
-                "start"
-                if _qbittorrent_major_version(version) >= QBITTORRENT_START_API_MAJOR
-                else "resume"
-            )
             self._request(
                 session,
                 "POST",
-                f"/api/v2/torrents/{endpoint}",
+                "/api/v2/torrents/start",
                 data={"hashes": hashes},
             )
 
@@ -228,15 +217,6 @@ def _as_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
-
-
-def _qbittorrent_major_version(version: str) -> int:
-    """Extract the qBittorrent major version, defaulting to the current API."""
-    normalized = version.strip().removeprefix("v")
-    try:
-        return int(normalized.split(".", maxsplit=1)[0])
-    except ValueError:
-        return QBITTORRENT_START_API_MAJOR
 
 
 def _effective_limit(

--- a/apps/qbittorrent/storage_cleanup.py
+++ b/apps/qbittorrent/storage_cleanup.py
@@ -1,4 +1,4 @@
-"""Offer deletion of the seeding torrent closest to its share limit."""
+"""Offer torrent deletion when storage is full and restart errored torrents."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from requests import RequestException, Response, Session
 
 BYTES_PER_UNIT: Final = 1024
 SECONDS_PER_MINUTE: Final = 60
+QBITTORRENT_START_API_MAJOR: Final = 5
 USE_GLOBAL_LIMIT: Final = -2.0
 ACTION_PREFIX: Final = "DELETE_QBT_TORRENT_"
 TORRENT_HASH_PATTERN: Final = compile_regex(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
@@ -112,6 +113,47 @@ class QbittorrentWebApi:
                 data={"hashes": torrent_hash, "deleteFiles": "true"},
             )
 
+    def restart_errored(self) -> list[str]:
+        """Start torrents currently reported in qBittorrent's errored filter."""
+        with self._authenticated_session() as session:
+            version = self._request(
+                session,
+                "GET",
+                "/api/v2/app/version",
+            ).text.strip()
+            torrents = self._json_list(
+                self._request(
+                    session,
+                    "GET",
+                    "/api/v2/torrents/info",
+                    params={"filter": "errored"},
+                ),
+            )
+            errored = [
+                torrent
+                for torrent in torrents
+                if TORRENT_HASH_PATTERN.fullmatch(
+                    str(torrent.get("hash", "")).lower(),
+                )
+            ]
+            if not errored:
+                return []
+
+            hashes = "|".join(str(torrent["hash"]).lower() for torrent in errored)
+            endpoint = (
+                "start"
+                if _qbittorrent_major_version(version) >= QBITTORRENT_START_API_MAJOR
+                else "resume"
+            )
+            self._request(
+                session,
+                "POST",
+                f"/api/v2/torrents/{endpoint}",
+                data={"hashes": hashes},
+            )
+
+        return [str(torrent.get("name", "Unknown torrent")) for torrent in errored]
+
     def _authenticated_session(self) -> Session:
         session = Session()
         session.headers.update({"Referer": f"{self.base_url}/"})
@@ -186,6 +228,15 @@ def _as_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _qbittorrent_major_version(version: str) -> int:
+    """Extract the qBittorrent major version, defaulting to the current API."""
+    normalized = version.strip().removeprefix("v")
+    try:
+        return int(normalized.split(".", maxsplit=1)[0])
+    except ValueError:
+        return QBITTORRENT_START_API_MAJOR
 
 
 def _effective_limit(
@@ -347,6 +398,7 @@ class QbittorrentStorageCleanup(Hass):
         if new_usage < self.reset_below:
             if self._threshold_active:
                 self._clear_notification()
+                self._restart_errored_torrents()
             self._threshold_active = False
             return
 
@@ -510,10 +562,13 @@ class QbittorrentStorageCleanup(Hass):
         self.run_in(self._post_delete_check, self.post_delete_check_delay)
 
     def _post_delete_check(self, _kwargs: dict[str, Any]) -> None:
-        """Offer another deletion if storage remains full after sensor refresh."""
+        """Restart errored torrents or offer another deletion after refresh."""
         self._post_delete_check_pending = False
         usage = self._usage(self.get_state(self.storage_entity))
-        if usage is None or usage < self.threshold:
+        if usage is None:
+            return
+        if usage < self.threshold:
+            self._restart_errored_torrents()
             return
 
         self._threshold_active = True
@@ -522,6 +577,28 @@ class QbittorrentStorageCleanup(Hass):
             usage,
         )
         self._offer_cleanup(usage)
+
+    def _restart_errored_torrents(self) -> None:
+        """Restart torrents that errored while scratch storage was full."""
+        try:
+            restarted = self.client.restart_errored()
+        except QbittorrentError as error:
+            self.error("Unable to restart errored qBittorrent torrents: %s", error)
+            self._notify(
+                title="Torrents were not restarted",
+                message=f"qBittorrent reported: {error}",
+                icon="mdi:restart-alert",
+                persistent=False,
+                sticky=False,
+            )
+            return
+
+        if restarted:
+            self.log(
+                "Restarted %i errored qBittorrent torrent(s): %s",
+                len(restarted),
+                ", ".join(restarted),
+            )
 
     def _notify(
         self,

--- a/apps/qbittorrent/storage_cleanup.py
+++ b/apps/qbittorrent/storage_cleanup.py
@@ -339,8 +339,11 @@ class QbittorrentStorageCleanup(Hass):
     def initialize(self) -> None:
         """Register storage and notification-action listeners."""
         self.storage_entity = str(self.args["storage_entity"])
-        self.threshold = float(self.args.get("threshold", 99.9))
-        self.reset_below = float(self.args.get("reset_below", self.threshold))
+        self.threshold_entity = str(self.args.get("threshold_entity", ""))
+        self.default_threshold = float(self.args.get("threshold", 99.9))
+        self.reset_below = float(
+            self.args.get("reset_below", self.default_threshold),
+        )
         self.post_delete_check_delay = max(
             float(self.args.get("post_delete_check_delay", 90)),
             1.0,
@@ -364,6 +367,8 @@ class QbittorrentStorageCleanup(Hass):
         self._post_delete_check_pending = False
 
         self.listen_state(self._storage_changed, self.storage_entity)
+        if self.threshold_entity:
+            self.listen_state(self._threshold_changed, self.threshold_entity)
         self.listen_event(
             self._notification_action,
             "mobile_app_notification_action",
@@ -373,7 +378,7 @@ class QbittorrentStorageCleanup(Hass):
     def _startup_check(self, _kwargs: dict[str, Any]) -> None:
         """Offer cleanup after reload when storage is already over the threshold."""
         usage = self._usage(self.get_state(self.storage_entity))
-        if usage is not None and usage >= self.threshold:
+        if usage is not None and usage >= self._current_threshold():
             self._threshold_active = True
             self._offer_cleanup(usage)
 
@@ -395,19 +400,47 @@ class QbittorrentStorageCleanup(Hass):
         if self._post_delete_check_pending:
             return
 
-        if new_usage < self.reset_below:
+        threshold = self._current_threshold()
+        if new_usage < min(self.reset_below, threshold):
             if self._threshold_active:
                 self._clear_notification()
                 self._restart_errored_torrents()
             self._threshold_active = False
             return
 
-        crossed_threshold = new_usage >= self.threshold and (
-            old_usage is None or old_usage < self.threshold
+        crossed_threshold = new_usage >= threshold and (
+            old_usage is None or old_usage < threshold
         )
         if crossed_threshold and not self._threshold_active:
             self._threshold_active = True
             self._offer_cleanup(new_usage)
+
+    def _threshold_changed(
+        self,
+        entity: str,
+        attribute: str,
+        old: Any,
+        new: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Re-evaluate cleanup when the configured threshold changes."""
+        del entity, attribute, kwargs
+        old_threshold = self._usage(old)
+        new_threshold = self._usage(new)
+        usage = self._usage(self.get_state(self.storage_entity))
+        if new_threshold is None or usage is None or self._post_delete_check_pending:
+            return
+
+        if usage < new_threshold:
+            if self._threshold_active:
+                self._clear_notification()
+            self._threshold_active = False
+            return
+
+        crossed_threshold = old_threshold is None or usage < old_threshold
+        if crossed_threshold and not self._threshold_active:
+            self._threshold_active = True
+            self._offer_cleanup(usage)
 
     def _offer_cleanup(self, usage: float) -> None:
         """Find the nearest-limit torrent and send a confirmation notification."""
@@ -567,16 +600,19 @@ class QbittorrentStorageCleanup(Hass):
         usage = self._usage(self.get_state(self.storage_entity))
         if usage is None:
             return
-        if usage < self.threshold:
+        threshold = self._current_threshold()
+        if usage >= threshold:
+            self._threshold_active = True
+            self.log(
+                "Storage remains at %.1f%% after deletion; offering another torrent",
+                usage,
+            )
+            self._offer_cleanup(usage)
+            return
+        if usage < min(self.reset_below, threshold):
             self._restart_errored_torrents()
             return
-
         self._threshold_active = True
-        self.log(
-            "Storage remains at %.1f%% after deletion; offering another torrent",
-            usage,
-        )
-        self._offer_cleanup(usage)
 
     def _restart_errored_torrents(self) -> None:
         """Restart torrents that errored while scratch storage was full."""
@@ -599,6 +635,13 @@ class QbittorrentStorageCleanup(Hass):
                 len(restarted),
                 ", ".join(restarted),
             )
+
+    def _current_threshold(self) -> float:
+        """Return the helper value, falling back to the YAML threshold."""
+        if not self.threshold_entity:
+            return self.default_threshold
+        threshold = self._usage(self.get_state(self.threshold_entity))
+        return self.default_threshold if threshold is None else threshold
 
     def _notify(
         self,

--- a/apps/qbittorrent/storage_cleanup.py
+++ b/apps/qbittorrent/storage_cleanup.py
@@ -431,16 +431,21 @@ class QbittorrentStorageCleanup(Hass):
         if new_threshold is None or usage is None or self._post_delete_check_pending:
             return
 
-        if usage < new_threshold:
+        if usage >= new_threshold:
+            crossed_threshold = old_threshold is None or usage < old_threshold
+            if crossed_threshold and not self._threshold_active:
+                self._offer_cleanup(usage)
+            self._threshold_active = True
+            return
+
+        if usage < min(self.reset_below, new_threshold):
             if self._threshold_active:
                 self._clear_notification()
+                self._restart_errored_torrents()
             self._threshold_active = False
             return
 
-        crossed_threshold = old_threshold is None or usage < old_threshold
-        if crossed_threshold and not self._threshold_active:
-            self._threshold_active = True
-            self._offer_cleanup(usage)
+        self._threshold_active = True
 
     def _offer_cleanup(self, usage: float) -> None:
         """Find the nearest-limit torrent and send a confirmation notification."""
@@ -600,6 +605,7 @@ class QbittorrentStorageCleanup(Hass):
         usage = self._usage(self.get_state(self.storage_entity))
         if usage is None:
             return
+        self._restart_errored_torrents()
         threshold = self._current_threshold()
         if usage >= threshold:
             self._threshold_active = True
@@ -609,13 +615,10 @@ class QbittorrentStorageCleanup(Hass):
             )
             self._offer_cleanup(usage)
             return
-        if usage < min(self.reset_below, threshold):
-            self._restart_errored_torrents()
-            return
-        self._threshold_active = True
+        self._threshold_active = False
 
     def _restart_errored_torrents(self) -> None:
-        """Restart torrents that errored while scratch storage was full."""
+        """Restart errored torrents after deleting scratch-storage content."""
         try:
             restarted = self.client.restart_errored()
         except QbittorrentError as error:


### PR DESCRIPTION


---



- fdc490d | fix: restart errored torrents after storage cleanup
- b635063 | feat: allow dynamic configuration of storage cleanup threshold
- 4eb27a9 | fix(storage_cleanup): restart errored torrents after deletion
- bd58c1c | refactor(storage_cleanup): simplify torrent restart logic
